### PR TITLE
Add MkDocs documentation site for ReadTheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ env/
 *.backup
 *.tmp
 
+site/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - cli
+    - requirements: docs/requirements.txt

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,172 @@
+# API Reference
+
+All public classes are importable directly from the top-level package:
+
+```python
+from samplesheet_parser import (
+    SampleSheetFactory,
+    SampleSheetV1,
+    SampleSheetV2,
+    SampleSheetConverter,
+    SampleSheetValidator,
+    SampleSheetDiff,
+    SampleSheetWriter,
+    SampleSheetMerger,
+    normalize_index_lengths,
+)
+```
+
+---
+
+## SampleSheetFactory
+
+| Method / attribute | Returns | Description |
+|---|---|---|
+| `create_parser(path, *, clean, experiment_id, parse)` | `SampleSheetV1 \| SampleSheetV2` | Auto-detect format and return the appropriate parser |
+| `get_umi_length()` | `int` | UMI length from the current parser |
+| `.version` | `SampleSheetVersion \| None` | Detected format version |
+
+---
+
+## SampleSheetV1 / SampleSheetV2 (shared interface)
+
+| Method / attribute | Returns | Description |
+|---|---|---|
+| `parse(do_clean=True)` | `None` | Parse all sections |
+| `samples()` | `list[dict]` | One record per unique sample |
+| `index_type()` | `str` | `"dual"`, `"single"`, or `"none"` |
+| `.adapters` | `list[str]` | Adapter sequences |
+| `.experiment_name` | `str \| None` | Run/experiment name |
+
+### V2-only
+
+| Method | Returns | Description |
+|---|---|---|
+| `get_umi_length()` | `int` | UMI length from `OverrideCycles` |
+| `get_read_structure()` | `ReadStructure` | Parsed read structure dataclass |
+
+---
+
+## SampleSheetConverter
+
+| Method | Returns | Description |
+|---|---|---|
+| `to_v2(output_path)` | `Path` | Convert IEM V1 → BCLConvert V2 |
+| `to_v1(output_path)` | `Path` | Convert BCLConvert V2 → IEM V1 (lossy) |
+| `.source_version` | `SampleSheetVersion \| None` | Auto-detected format of the input |
+
+---
+
+## SampleSheetValidator
+
+| Method | Returns | Description |
+|---|---|---|
+| `validate(sheet, *, min_hamming_distance=3)` | `ValidationResult` | Run all checks; returns structured result |
+
+### ValidationResult
+
+| Attribute / method | Type | Description |
+|---|---|---|
+| `is_valid` | `bool` | `False` if any errors present |
+| `errors` | `list[ValidationIssue]` | Structured error records |
+| `warnings` | `list[ValidationIssue]` | Structured warning records |
+| `summary()` | `str` | One-line human-readable summary |
+
+### ValidationIssue
+
+| Attribute | Type | Description |
+|---|---|---|
+| `code` | `str` | e.g. `"DUPLICATE_INDEX"` |
+| `message` | `str` | Human-readable description |
+| `context` | `dict` | Relevant sample IDs, lane, etc. |
+
+---
+
+## SampleSheetDiff
+
+| Method | Returns | Description |
+|---|---|---|
+| `compare()` | `DiffResult` | Full comparison across header, reads, settings, and samples |
+
+### DiffResult
+
+| Attribute / method | Type | Description |
+|---|---|---|
+| `has_changes` | `bool` | `True` if any difference detected |
+| `summary()` | `str` | Human-readable one-paragraph summary |
+| `header_changes` | `list[HeaderChange]` | Header, reads, and settings diffs |
+| `samples_added` | `list[dict]` | Records present in new sheet only |
+| `samples_removed` | `list[dict]` | Records present in old sheet only |
+| `sample_changes` | `list[SampleChange]` | Per-sample field-level diffs |
+| `source_version` | `SampleSheetVersion` | Format of the old sheet |
+| `target_version` | `SampleSheetVersion` | Format of the new sheet |
+
+---
+
+## SampleSheetWriter
+
+| Method / attribute | Returns | Description |
+|---|---|---|
+| `SampleSheetWriter(version=)` | — | Instantiate for `SampleSheetVersion.V1` or `.V2` |
+| `from_sheet(sheet, version=)` | `SampleSheetWriter` | Load a parsed sheet for editing; optionally change format |
+| `set_header(*, run_name, platform, ...)` | `self` | Set header fields (fluent) |
+| `set_reads(*, read1, read2, index1, index2)` | `self` | Set read cycle counts (fluent) |
+| `set_adapter(adapter_read1, adapter_read2)` | `self` | Set adapter sequences (fluent) |
+| `set_override_cycles(override)` | `self` | Set `OverrideCycles` — V2 only (fluent) |
+| `set_software_version(version)` | `self` | Set `SoftwareVersion` — V2 only (fluent) |
+| `set_setting(key, value)` | `self` | Set an arbitrary settings key/value (fluent) |
+| `add_sample(sample_id, *, index, ...)` | `self` | Append a sample row (fluent) |
+| `remove_sample(sample_id, *, lane=)` | `self` | Remove sample(s) by ID, optionally scoped to a lane (fluent) |
+| `update_sample(sample_id, *, lane=, **fields)` | `self` | Update fields on an existing sample in-place (fluent) |
+| `write(path, *, validate=True)` | `Path` | Serialise to disk; validates first by default |
+| `to_string()` | `str` | Serialise to string without writing to disk |
+| `.sample_count` | `int` | Number of samples currently in the writer |
+| `.sample_ids` | `list[str]` | Sample IDs currently in the writer |
+
+---
+
+## SampleSheetMerger
+
+| Method / attribute | Returns | Description |
+|---|---|---|
+| `SampleSheetMerger(target_version=, min_hamming_distance=3)` | — | Instantiate with target format and optional Hamming threshold |
+| `add(path)` | `self` | Register an input sheet path (fluent) |
+| `merge(output_path, *, validate=True, abort_on_conflicts=True)` | `MergeResult` | Run the merge and write output |
+
+### MergeResult
+
+| Attribute / method | Type | Description |
+|---|---|---|
+| `has_conflicts` | `bool` | `True` if any conflict recorded |
+| `sample_count` | `int` | Samples in the merged output |
+| `output_path` | `Path \| None` | Path written; `None` if write was aborted |
+| `source_versions` | `dict[str, str]` | Per-input-file detected version |
+| `conflicts` | `list[MergeConflict]` | Structured conflict records |
+| `warnings` | `list[MergeConflict]` | Structured warning records |
+| `summary()` | `str` | One-line human-readable summary |
+
+---
+
+## normalize_index_lengths
+
+```python
+normalize_index_lengths(
+    samples: list[dict],
+    strategy: str,                  # "trim" or "pad"
+    index1_key: str | None = None,  # auto-detected if None
+    index2_key: str | None = None,  # auto-detected if None
+) -> list[dict]
+```
+
+Normalizes index sequence lengths across a list of sample dicts. See [Index Utilities](guide/index_utils.md) for details.
+
+---
+
+## Enums
+
+```python
+from samplesheet_parser.enums import SampleSheetVersion, InstrumentPlatform, UMILocation
+
+SampleSheetVersion.V1   # IEM / bcl2fastq
+SampleSheetVersion.V2   # BCLConvert
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+The full changelog is maintained in the repository:
+
+--8<-- "CHANGELOG.md"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,83 @@
+# CI Integration
+
+The CLI exits with meaningful codes (`0` = clean, `1` = issues, `2` = error), making it easy to wire into automated pipelines.
+
+## GitHub Actions
+
+Add a validation step to any workflow that touches `SampleSheet.csv`:
+
+```yaml
+# .github/workflows/validate-samplesheet.yml
+name: Validate SampleSheet
+
+on:
+  push:
+    paths:
+      - '**/SampleSheet.csv'
+  pull_request:
+    paths:
+      - '**/SampleSheet.csv'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install "samplesheet-parser[cli]"
+
+      - name: Validate SampleSheet
+        run: samplesheet validate SampleSheet.csv --format json
+```
+
+## pre-commit hook
+
+Gate commits that touch any `SampleSheet.csv` in the repository:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: samplesheet-validate
+        name: Validate SampleSheet.csv
+        entry: samplesheet validate
+        language: python
+        additional_dependencies: ["samplesheet-parser[cli]"]
+        files: SampleSheet\.csv$
+        pass_filenames: true
+```
+
+Install and run once to verify:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run samplesheet-validate --all-files
+```
+
+## Stricter Hamming distance in CI
+
+If your lab uses longer indexes (10 bp+), raise the minimum Hamming distance threshold to catch borderline cases earlier:
+
+```bash
+samplesheet validate SampleSheet.csv --min-hamming 4
+```
+
+## Using JSON output in scripts
+
+All commands support `--format json` for machine-readable output:
+
+```bash
+result=$(samplesheet validate SampleSheet.csv --format json)
+is_valid=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin)['is_valid'])")
+
+if [ "$is_valid" != "True" ]; then
+  echo "SampleSheet validation failed"
+  exit 1
+fi
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,169 @@
+# CLI Reference
+
+Install the CLI extra to get the `samplesheet` command:
+
+```bash
+pip install "samplesheet-parser[cli]"
+# or via conda:
+conda install -c bioconda samplesheet-parser
+```
+
+## Global options
+
+```
+samplesheet --version   # Print version and exit
+samplesheet --help      # Show help
+```
+
+## Exit codes
+
+All commands use consistent exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success / no issues |
+| `1` | Issues found (errors, conflicts, or differences detected) |
+| `2` | Usage error (missing file, bad argument, parse failure) |
+
+---
+
+## info
+
+Show a quick summary of a sheet without full validation.
+
+```bash
+samplesheet info SampleSheet.csv
+samplesheet info SampleSheet.csv --format json
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--format` / `-f` | `text` | Output format: `text` or `json` |
+
+**Text output:**
+```
+File:          SampleSheet.csv
+Format:        V2
+Samples:       8
+Lanes:         1
+Index type:    dual
+Read lengths:  151 + 151
+Adapters:      CTGTCTCTTATACACATCT
+Experiment:    MyRun_20240115
+```
+
+**JSON output:**
+```json
+{
+  "file": "SampleSheet.csv",
+  "format": "V2",
+  "sample_count": 8,
+  "lanes": ["1"],
+  "index_type": "dual",
+  "read_lengths": ["151", "151"],
+  "adapters": ["CTGTCTCTTATACACATCT"],
+  "experiment_name": "MyRun_20240115",
+  "instrument": null
+}
+```
+
+---
+
+## validate
+
+Validate a sheet for index, adapter, and structural issues.
+
+```bash
+samplesheet validate SampleSheet.csv
+samplesheet validate SampleSheet.csv --format json
+samplesheet validate SampleSheet.csv --min-hamming 4
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--format` / `-f` | `text` | Output format: `text` or `json` |
+| `--min-hamming` | `3` | Minimum Hamming distance between indexes |
+
+**Exit codes:** `0` = valid, `1` = errors found, `2` = parse/usage error.
+
+---
+
+## convert
+
+Convert between V1 (IEM/bcl2fastq) and V2 (BCLConvert) formats.
+
+```bash
+samplesheet convert SampleSheet_v1.csv --to v2 --output SampleSheet_v2.csv
+samplesheet convert SampleSheet_v2.csv --to v1 --output SampleSheet_v1.csv
+samplesheet convert SampleSheet_v1.csv --to v2 --output out.csv --format json
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--to` | `v2` | Target format: `v1` or `v2` |
+| `--output` / `-o` | `SampleSheet_converted.csv` | Output file path |
+| `--format` / `-f` | `text` | Output format: `text` or `json` |
+
+!!! warning "V2 → V1 is lossy"
+    V2-only fields (`OverrideCycles`, `InstrumentPlatform`, etc.) are dropped with a warning.
+
+**JSON output:**
+```json
+{
+  "input": "SampleSheet_v1.csv",
+  "output": "SampleSheet_v2.csv",
+  "source_version": "V1",
+  "target_version": "V2"
+}
+```
+
+---
+
+## diff
+
+Compare two sheets across any combination of V1 and V2.
+
+```bash
+samplesheet diff old/SampleSheet.csv new/SampleSheet.csv
+samplesheet diff old/SampleSheet.csv new/SampleSheet.csv --format json
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--format` / `-f` | `text` | Output format: `text` or `json` |
+
+**Exit codes:** `0` = identical, `1` = differences detected, `2` = parse/usage error.
+
+Useful in CI pre-run checks — gate a pipeline on sheet changes.
+
+---
+
+## merge
+
+Merge multiple per-project sheets into one combined sheet.
+
+```bash
+samplesheet merge ProjectA.csv ProjectB.csv --output combined.csv
+samplesheet merge ProjectA.csv ProjectB.csv ProjectC.csv --to v1 --output combined.csv
+samplesheet merge ProjectA.csv ProjectB.csv --output combined.csv --force
+samplesheet merge ProjectA.csv ProjectB.csv --output combined.csv --format json
+```
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--output` / `-o` | `SampleSheet_combined.csv` | Output file path |
+| `--to` | `v2` | Target format: `v1` or `v2` |
+| `--format` / `-f` | `text` | Output format: `text` or `json` |
+| `--force` | `False` | Write output even if conflicts are found |
+
+**Exit codes:** `0` = clean merge, `1` = conflicts or warnings, `2` = bad arguments or unreadable files.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,5 @@
+# Contributing
+
+The full contributing guide is maintained in the repository:
+
+--8<-- "CONTRIBUTING.md"

--- a/docs/guide/conversion.md
+++ b/docs/guide/conversion.md
@@ -1,0 +1,54 @@
+# Conversion
+
+## V1 → V2
+
+```python
+from samplesheet_parser import SampleSheetConverter
+
+converter = SampleSheetConverter("SampleSheet_v1.csv")
+out = converter.to_v2("SampleSheet_v2.csv")
+
+print(out)                          # Path("SampleSheet_v2.csv")
+print(converter.source_version)     # SampleSheetVersion.V1
+```
+
+The converter maps IEM V1 fields to BCLConvert V2 equivalents:
+
+| V1 field | V2 field |
+|---|---|
+| `IEMFileVersion` | `FileFormatVersion: 2` |
+| `[Data]` section | `[BCLConvert_Data]` section |
+| `Sample_ID` | `Sample_ID` |
+| `index` | `Index` |
+| `index2` | `Index2` |
+| `[Reads]` lengths | `Read1Cycles` / `Read2Cycles` in `[Reads]` |
+| `Adapter` in `[Settings]` | `AdapterRead1` in `[BCLConvert_Settings]` |
+
+## V2 → V1 (lossy)
+
+```python
+converter = SampleSheetConverter("SampleSheet_v2.csv")
+out = converter.to_v1("SampleSheet_v1.csv")
+```
+
+!!! warning "Lossy conversion"
+    V2-only fields are dropped during V2 → V1 conversion:
+
+    - `OverrideCycles`
+    - `InstrumentPlatform`
+    - `FileFormatVersion`
+    - `[BCLConvert_Settings]` keys with no V1 equivalent
+
+    A warning is logged for each dropped field.
+
+## Round-trip
+
+```python
+converter = SampleSheetConverter("SampleSheet_v1.csv")
+converter.to_v2("temp_v2.csv")
+
+converter2 = SampleSheetConverter("temp_v2.csv")
+converter2.to_v1("roundtrip_v1.csv")
+```
+
+Sample IDs survive a V1 → V2 → V1 round-trip. V2-only fields do not survive a V2 → V1 → V2 round-trip.

--- a/docs/guide/diffing.md
+++ b/docs/guide/diffing.md
@@ -1,0 +1,59 @@
+# Diffing
+
+`SampleSheetDiff` compares two sheets — any combination of V1 and V2 — and returns a structured `DiffResult`.
+
+## Basic usage
+
+```python
+from samplesheet_parser import SampleSheetDiff
+
+result = SampleSheetDiff("old/SampleSheet.csv", "new/SampleSheet.csv").compare()
+
+print(result.summary())
+# Diff (V1 → V2):
+#   2 header/settings change(s)
+#   1 sample(s) added: SAMPLE_009
+#   1 sample(s) with field changes
+
+print(result.has_changes)   # True
+```
+
+## What is compared
+
+| Dimension | What is compared |
+|---|---|
+| Header | Key/value changes in `[Header]` / `[BCLConvert_Settings]` |
+| Reads | Read length or cycle count changes |
+| Samples added / removed | Keyed on `Sample_ID` + `Lane` |
+| Sample field changes | Per-sample field-level diffs (index, project, etc.) |
+
+## Inspecting results
+
+```python
+# Header / settings changes
+for change in result.header_changes:
+    print(f"{change.field}: {change.old_value!r} → {change.new_value!r}")
+
+# Added / removed samples
+for s in result.samples_added:
+    print(f"Added: {s.get('Sample_ID') or s.get('sample_id')}")
+
+for s in result.samples_removed:
+    print(f"Removed: {s.get('Sample_ID') or s.get('sample_id')}")
+
+# Per-sample field changes
+for sc in result.sample_changes:
+    print(f"{sc.sample_id} (lane {sc.lane}):")
+    for field, (old, new) in sc.changes.items():
+        print(f"  {field}: {old!r} → {new!r}")
+```
+
+## Cross-format diff
+
+V1-only metadata columns (`I7_Index_ID`, `I5_Index_ID`, `Sample_Name`, `Description`) are suppressed when comparing V1 against V2 so that format differences do not generate noise.
+
+```python
+# V1 vs its own V2 conversion — should show zero meaningful changes
+result = SampleSheetDiff("SampleSheet_v1.csv", "SampleSheet_v2.csv").compare()
+print(result.has_changes)   # False (or only adapter field name differences)
+```

--- a/docs/guide/index_utils.md
+++ b/docs/guide/index_utils.md
@@ -1,0 +1,60 @@
+# Index Utilities
+
+## normalize_index_lengths
+
+Normalizes index sequence lengths across a list of sample dicts before merging sheets with mixed-length indexes.
+
+```python
+from samplesheet_parser import normalize_index_lengths
+
+samples = sheet.samples()
+
+# Trim all indexes to the shortest length
+normalized = normalize_index_lengths(samples, strategy="trim")
+
+# Pad shorter indexes to the longest length using "N" wildcards
+normalized = normalize_index_lengths(samples, strategy="pad")
+```
+
+### Strategies
+
+| Strategy | Behaviour |
+|---|---|
+| `"trim"` | Trims all indexes to the shortest sequence present |
+| `"pad"` | Pads shorter indexes to the longest length using `"N"` wildcard characters |
+
+!!! note "BCLConvert compatibility"
+    `"N"` padding is supported by BCLConvert ≥ 3.9 and bcl2fastq ≥ 2.20.
+
+### Dual-index normalization
+
+Both I7 (`Index` / `index`) and I5 (`Index2` / `index2`) are normalized independently:
+
+```python
+normalized = normalize_index_lengths(samples, strategy="pad")
+```
+
+### Field name auto-detection
+
+The utility auto-detects V1-style (`index` / `index2`) and V2-style (`Index` / `Index2`) field names. Use explicit overrides if your samples use custom field names:
+
+```python
+normalized = normalize_index_lengths(
+    samples,
+    strategy="trim",
+    index1_key="custom_index",
+    index2_key="custom_index2",
+)
+```
+
+### Typical workflow before merging
+
+```python
+from samplesheet_parser import SampleSheetMerger, normalize_index_lengths
+from samplesheet_parser.enums import SampleSheetVersion
+
+# Normalize each sheet's samples before merging
+merger = SampleSheetMerger(target_version=SampleSheetVersion.V2)
+merger.add("ProjectA.csv").add("ProjectB.csv")
+result = merger.merge("combined.csv")
+```

--- a/docs/guide/merging.md
+++ b/docs/guide/merging.md
@@ -1,0 +1,87 @@
+# Merging
+
+`SampleSheetMerger` combines multiple per-project sample sheets into one sheet for a flow cell run, detecting conflicts before writing.
+
+## Basic usage
+
+```python
+from samplesheet_parser import SampleSheetMerger
+from samplesheet_parser.enums import SampleSheetVersion
+
+result = (
+    SampleSheetMerger(target_version=SampleSheetVersion.V2)
+    .add("ProjectA.csv")
+    .add("ProjectB.csv")
+    .add("ProjectC.csv")
+    .merge("SampleSheet_combined.csv")
+)
+
+print(result.summary())
+# Merged 3 sheet(s) → SampleSheet_combined.csv (12 samples) — 0 conflict(s), 0 warning(s)
+```
+
+## Conflict detection
+
+The merger checks for:
+
+| Code | Level | Description |
+|---|---|---|
+| `PARSE_ERROR` | conflict | An input sheet could not be parsed |
+| `INDEX_COLLISION` | conflict | The same index appears in the same lane across two sheets |
+| `READ_LENGTH_CONFLICT` | conflict | Sheets specify different read lengths or cycle counts |
+| `MERGE_VALIDATION_ERROR` | conflict | Post-merge validation of the combined sheet failed |
+| `MIXED_FORMAT` | warning | Input sheets are a mix of V1 and V2 formats |
+| `INDEX_DISTANCE_TOO_LOW` | warning | Cross-sheet index pair has Hamming distance below threshold |
+| `ADAPTER_CONFLICT` | warning | Adapter sequences differ between sheets |
+| `INCOMPLETE_SAMPLE_RECORD` | warning | A sample row is missing `Sample_ID` or index |
+
+## Handling conflicts
+
+By default, `merge()` aborts (does not write output) if any conflicts are found:
+
+```python
+result = merger.merge("combined.csv")
+
+if result.has_conflicts:
+    for c in result.conflicts:
+        print(c)
+    # [CONFLICT] INDEX_COLLISION: Index 'ATTACTCG+TATAGCCT' in lane 1
+    #   appears in both ProjectA.csv and ProjectB.csv
+```
+
+Pass `abort_on_conflicts=False` to write output even when conflicts exist:
+
+```python
+result = merger.merge("combined.csv", abort_on_conflicts=False)
+```
+
+## Mixed V1/V2 inputs
+
+Mixed-format inputs are automatically converted to the target version:
+
+```python
+# ProjectA is V1, ProjectB is V2 — both converted to V2 for output
+merger = SampleSheetMerger(target_version=SampleSheetVersion.V2)
+merger.add("ProjectA_v1.csv").add("ProjectB_v2.csv")
+result = merger.merge("combined_v2.csv")
+```
+
+A `MIXED_FORMAT` warning is emitted when this happens.
+
+## Custom Hamming threshold
+
+```python
+merger = SampleSheetMerger(target_version=SampleSheetVersion.V2, min_hamming_distance=4)
+```
+
+## Inspecting MergeResult
+
+```python
+result.has_conflicts        # bool
+result.sample_count         # int — samples in merged output
+result.output_path          # Path | None — None if write was aborted
+result.source_versions      # dict[str, str] — per-file detected version
+result.conflicts            # list[MergeConflict]
+result.warnings             # list[MergeConflict]
+result.summary()            # str — one-line human-readable summary
+```

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -1,0 +1,84 @@
+# Parsing
+
+## Format auto-detection
+
+`SampleSheetFactory` uses a three-step detection strategy — no format hints required from the caller:
+
+1. **Header discriminator** — scan `[Header]` for `FileFormatVersion` (→ V2) or `IEMFileVersion` (→ V1)
+2. **Section name scan** — if no header key found, look for `[BCLConvert_Settings]` / `[BCLConvert_Data]` in the full file (→ V2)
+3. **Default** — fall back to V1 (broadest compatibility with legacy files)
+
+The detector reads only as much of the file as needed — stopping after `[Header]` in the common case.
+
+```python
+from samplesheet_parser import SampleSheetFactory
+
+factory = SampleSheetFactory()
+sheet = factory.create_parser("SampleSheet.csv", parse=True)
+
+print(factory.version)   # SampleSheetVersion.V1 or .V2
+```
+
+## V1 parser
+
+```python
+from samplesheet_parser import SampleSheetV1
+
+sheet = SampleSheetV1("SampleSheet.csv")
+sheet.parse()
+
+print(sheet.experiment_name)   # "MyRun_20240115"
+print(sheet.read_lengths)      # [151, 151]
+print(sheet.adapters)          # ["CTGTCTCTTATACACATCT"]
+print(sheet.index_type())      # "dual"
+
+for sample in sheet.samples():
+    print(sample["sample_id"], sample["index"], sample["index2"])
+```
+
+## V2 parser
+
+```python
+from samplesheet_parser import SampleSheetV2
+
+sheet = SampleSheetV2("SampleSheet.csv")
+sheet.parse()
+
+print(sheet.reads)             # {"Read1Cycles": 151, "Read2Cycles": 151}
+print(sheet.adapters)          # ["CTGTCTCTTATACACATCT"]
+print(sheet.index_type())      # "dual"
+
+for sample in sheet.samples():
+    print(sample["Sample_ID"], sample["Index"], sample["Index2"])
+```
+
+## UMI / OverrideCycles parsing
+
+The V2 `OverrideCycles` field encodes read structure including UMI positions:
+
+| OverrideCycles | UMI length | UMI location |
+|---|---|---|
+| `Y151;I10;I10;Y151` | 0 | — |
+| `Y151;I10U9;I10;Y151` | 9 | `index2` |
+| `U5Y146;I8;I8;U5Y146` | 5 | `read1` |
+
+```python
+# OverrideCycles: Y151;I10U9;I10;Y151 → 9 bp UMI in Index1
+print(sheet.get_umi_length())       # 9
+rs = sheet.get_read_structure()
+print(rs.umi_location)              # "index2"
+print(rs.read_structure)
+# {"read1_template": 151, "index2_length": 10, "index2_umi": 9, ...}
+```
+
+## Shared interface
+
+Both `SampleSheetV1` and `SampleSheetV2` expose:
+
+| Method / attribute | Returns | Description |
+|---|---|---|
+| `parse(do_clean=True)` | `None` | Parse all sections |
+| `samples()` | `list[dict]` | One record per unique sample |
+| `index_type()` | `str` | `"dual"`, `"single"`, or `"none"` |
+| `.adapters` | `list[str]` | Adapter sequences |
+| `.experiment_name` | `str \| None` | Run/experiment name |

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart
+
+## Auto-detect format (recommended)
+
+The simplest entry point. `SampleSheetFactory` detects V1 vs V2 automatically using a three-step strategy and returns the correct parser.
+
+```python
+from samplesheet_parser import SampleSheetFactory
+
+factory = SampleSheetFactory()
+sheet = factory.create_parser("SampleSheet.csv", parse=True)
+
+print(factory.version)      # SampleSheetVersion.V1 or .V2
+print(sheet.index_type())   # "dual", "single", or "none"
+
+for sample in sheet.samples():
+    print(sample["sample_id"], sample["index"])
+```
+
+## Validate a sheet
+
+```python
+from samplesheet_parser import SampleSheetFactory, SampleSheetValidator
+
+sheet = SampleSheetFactory().create_parser("SampleSheet.csv", parse=True)
+result = SampleSheetValidator().validate(sheet)
+
+print(result.summary())
+# PASS — 0 error(s), 2 warning(s)
+
+for w in result.warnings:
+    print(w)
+
+for err in result.errors:
+    print(err)
+```
+
+## Convert between formats
+
+```python
+from samplesheet_parser import SampleSheetConverter
+
+# V1 → V2
+SampleSheetConverter("SampleSheet_v1.csv").to_v2("SampleSheet_v2.csv")
+
+# V2 → V1  (lossy — V2-only fields are dropped with a warning)
+SampleSheetConverter("SampleSheet_v2.csv").to_v1("SampleSheet_v1.csv")
+```
+
+## CLI
+
+```bash
+# Install the CLI extra
+pip install "samplesheet-parser[cli]"
+
+# Validate
+samplesheet validate SampleSheet.csv
+
+# Convert
+samplesheet convert SampleSheet_v1.csv --to v2 --output SampleSheet_v2.csv
+
+# Diff
+samplesheet diff old/SampleSheet.csv new/SampleSheet.csv
+
+# Merge
+samplesheet merge ProjectA.csv ProjectB.csv --output combined.csv
+```
+
+See the full [CLI Reference](../cli.md) for all options.

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,0 +1,59 @@
+# Validation
+
+## Basic usage
+
+```python
+from samplesheet_parser import SampleSheetFactory, SampleSheetValidator
+
+sheet = SampleSheetFactory().create_parser("SampleSheet.csv", parse=True)
+result = SampleSheetValidator().validate(sheet)
+
+print(result.is_valid)     # True / False
+print(result.summary())    # "PASS — 0 error(s), 0 warning(s)"
+
+for err in result.errors:
+    print(err)
+
+for w in result.warnings:
+    print(w)
+```
+
+## Validation checks
+
+| Code | Level | Description |
+|---|---|---|
+| `EMPTY_SAMPLES` | error | No samples in Data section |
+| `INVALID_INDEX_CHARS` | error | Index contains non-ACGTN characters |
+| `INDEX_TOO_LONG` | error | Index longer than 24 bp |
+| `DUPLICATE_INDEX` | error | Two samples share an index in the same lane |
+| `DUPLICATE_SAMPLE_ID` | error | Same `Sample_ID` appears twice in one lane |
+| `INDEX_TOO_SHORT` | warning | Index shorter than 6 bp |
+| `INDEX_DISTANCE_TOO_LOW` | warning | Hamming distance between two indexes < threshold |
+| `NO_ADAPTERS` | warning | No adapter sequences configured |
+| `ADAPTER_MISMATCH` | warning | Adapter is non-standard |
+
+## Hamming distance checking
+
+Indexes that are too similar cause read bleed-through between samples during demultiplexing — a common cause of low-quality runs that is not caught by a simple duplicate check.
+
+The validator computes the Hamming distance between every pair of indexes within each lane. For dual-index sheets, the I7 and I5 sequences are combined before comparison, so a pair that is close on I7 but well-separated on I5 is not incorrectly flagged.
+
+```python
+# Default threshold: 3
+result = SampleSheetValidator().validate(sheet)
+
+# Custom threshold — stricter for longer indexes
+result = SampleSheetValidator().validate(sheet, min_hamming_distance=4)
+```
+
+## Structured results
+
+```python
+result.is_valid          # bool — False if any errors present
+result.summary()         # str — one-line human-readable summary
+
+for issue in result.errors:
+    print(issue.code)      # e.g. "DUPLICATE_INDEX"
+    print(issue.message)   # human-readable description
+    print(issue.context)   # dict with relevant sample IDs, lane, etc.
+```

--- a/docs/guide/writing.md
+++ b/docs/guide/writing.md
@@ -1,0 +1,82 @@
+# Writing & Editing
+
+`SampleSheetWriter` provides a fluent API for building new sheets from scratch or editing existing ones.
+
+## Build a V2 sheet from scratch
+
+```python
+from samplesheet_parser import SampleSheetWriter
+from samplesheet_parser.enums import SampleSheetVersion
+
+writer = SampleSheetWriter(version=SampleSheetVersion.V2)
+writer.set_header(run_name="MyRun_20240115", platform="NovaSeqXSeries")
+writer.set_reads(read1=151, read2=151, index1=10, index2=10)
+writer.set_adapter("CTGTCTCTTATACACATCT")
+writer.set_override_cycles("Y151;I10;I10;Y151")
+writer.add_sample("SAMPLE_001", index="ATTACTCGAT", index2="TATAGCCTGT", project="Proj")
+writer.add_sample("SAMPLE_002", index="TCCGGAGACC", index2="ATAGAGGCAC", project="Proj")
+writer.write("SampleSheet.csv")   # validates before writing by default
+```
+
+## Build a V1 sheet from scratch
+
+```python
+writer = SampleSheetWriter(version=SampleSheetVersion.V1)
+writer.set_header(run_name="MyRun_20240115", experiment_name="Experiment1")
+writer.set_reads(read1=151, read2=151)
+writer.set_adapter("CTGTCTCTTATACACATCT")
+writer.add_sample(
+    "SAMPLE_001", lane="1",
+    index="ATTACTCG", index2="TATAGCCT",
+    project="ProjectA",
+)
+writer.write("SampleSheet_v1.csv")
+```
+
+## Edit an existing sheet
+
+```python
+from samplesheet_parser import SampleSheetFactory, SampleSheetWriter
+
+sheet = SampleSheetFactory().create_parser("SampleSheet.csv", parse=True)
+editor = SampleSheetWriter.from_sheet(sheet)
+
+# Fix a wrong index
+editor.update_sample("SAMPLE_002", index="GGGGGGGGGG")
+
+# Remove a sample that was added by mistake
+editor.remove_sample("SAMPLE_005")
+
+editor.write("SampleSheet_updated.csv")
+```
+
+## Convert format while editing
+
+```python
+# Load V1, edit, write out as V2
+editor = SampleSheetWriter.from_sheet(sheet, version=SampleSheetVersion.V2)
+editor.set_override_cycles("Y151;I10;I10;Y151")
+editor.write("SampleSheet_v2.csv")
+```
+
+## Inspect without writing
+
+```python
+print(writer.sample_count)   # 2
+print(writer.sample_ids)     # ["SAMPLE_001", "SAMPLE_002"]
+print(writer.to_string())    # full CSV content as a string
+```
+
+## Validation on write
+
+`write()` runs `SampleSheetValidator` before writing by default. Pass `validate=False` to skip:
+
+```python
+writer.write("out.csv", validate=False)
+```
+
+If validation fails, a `ValueError` is raised with the full list of errors — the file is not written.
+
+## CSV safety
+
+`SampleSheetWriter` rejects commas, newlines, and quotes in all free-text inputs (`sample_id`, `index`, `project`, adapter sequences, custom column keys/values) at input time with a clear error message — preventing malformed CSVs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# samplesheet-parser
+
+**Format-agnostic parser for Illumina SampleSheet.csv files.**
+
+Supports both the classic IEM V1 format (bcl2fastq era) and the modern BCLConvert V2 format (NovaSeq X series) — with automatic format detection, bidirectional conversion, index validation, Hamming distance checking, diff comparison, multi-sheet merging, programmatic sheet creation, and a full-featured CLI.
+
+[![PyPI version](https://img.shields.io/pypi/v/samplesheet-parser.svg)](https://pypi.org/project/samplesheet-parser/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Tests](https://github.com/chaitanyakasaraneni/samplesheet-parser/actions/workflows/ci.yml/badge.svg)](https://github.com/chaitanyakasaraneni/samplesheet-parser/actions)
+[![codecov](https://codecov.io/gh/chaitanyakasaraneni/samplesheet-parser/branch/main/graph/badge.svg?token=CODECOV_TOKEN)](https://codecov.io/gh/chaitanyakasaraneni/samplesheet-parser)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18989694.svg)](https://doi.org/10.5281/zenodo.18989694)
+
+![samplesheet-parser overview](https://raw.githubusercontent.com/chaitanyakasaraneni/samplesheet-parser/main/images/samplesheet_parser_arch_v03.png)
+
+---
+
+## The problem this solves
+
+Labs running mixed instrument fleets — older NovaSeq 6000 alongside newer NovaSeq X series — produce two incompatible SampleSheet formats. BCLConvert V2 sheets use `[BCLConvert_Settings]` / `[BCLConvert_Data]` sections, `OverrideCycles` for UMI encoding, and `FileFormatVersion` in the header. IEM V1 sheets use `IEMFileVersion` and a flat `[Data]` section.
+
+Existing tools either hard-code one format or require the caller to know which format they have. `samplesheet-parser` auto-detects the format, exposes a consistent interface for both, converts between formats, validates index integrity (including Hamming distance), diffs sheets to catch accidental changes before a run starts, and writes new sheets programmatically — so you never have to hand-edit a CSV again.
+
+---
+
+## Key features
+
+| Feature | Description |
+|---|---|
+| **Auto-detection** | Three-step format detection — no hints required |
+| **V1 & V2 parsing** | Consistent `samples()` / `index_type()` interface for both formats |
+| **Bidirectional conversion** | V1 → V2 and V2 → V1 (lossy, with warnings) |
+| **Validation** | 9 checks covering index chars, length, duplicates, Hamming distance, adapters |
+| **Diff** | Cross-format structural comparison with per-field change records |
+| **Merge** | Combine multiple per-project sheets with collision detection |
+| **Writer** | Fluent API for building or editing sheets programmatically |
+| **CLI** | Full shell interface with `--format json` for pipeline integration |
+| **UMI parsing** | Decode `OverrideCycles` to extract UMI length and location |
+
+---
+
+## Quickstart
+
+```bash
+pip install samplesheet-parser
+```
+
+```python
+from samplesheet_parser import SampleSheetFactory, SampleSheetValidator
+
+sheet = SampleSheetFactory().create_parser("SampleSheet.csv", parse=True)
+result = SampleSheetValidator().validate(sheet)
+print(result.summary())
+# PASS — 0 error(s), 0 warning(s)
+```
+
+See [Installation](installation.md) for full setup options, or jump to the [Quickstart guide](guide/quickstart.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,44 @@
+# Installation
+
+## Requirements
+
+- Python 3.12 or higher
+- No mandatory runtime dependencies beyond [`loguru`](https://github.com/Delgan/loguru)
+
+## pip (recommended)
+
+```bash
+# Core library — parsing, validation, conversion, diff, merge, writer
+pip install samplesheet-parser
+
+# With the CLI (adds typer as a dependency)
+pip install "samplesheet-parser[cli]"
+```
+
+## conda / Bioconda
+
+!!! note "Bioconda package pending"
+    The Bioconda recipe has been submitted and is awaiting review. Once merged, install with:
+
+    ```bash
+    conda install -c bioconda samplesheet-parser
+    ```
+
+    The Bioconda package includes the `samplesheet` CLI by default.
+
+## Development install
+
+```bash
+git clone https://github.com/chaitanyakasaraneni/samplesheet-parser.git
+cd samplesheet-parser
+pip install -e ".[dev,cli]"
+```
+
+## Verifying the install
+
+```bash
+python -c "import samplesheet_parser; print(samplesheet_parser.__version__)"
+
+# If you installed the CLI extra:
+samplesheet --version
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.25
+mkdocs-autorefs>=1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: samplesheet-parser
+site_description: Format-agnostic parser for Illumina SampleSheet.csv files — supports IEM V1 and BCLConvert V2
+site_url: https://illumina-samplesheet.readthedocs.io
+repo_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+repo_name: chaitanyakasaraneni/samplesheet-parser
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            merge_init_into_class: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.snippets:
+      base_path: .
+      check_paths: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - User Guide:
+    - Quickstart: guide/quickstart.md
+    - Parsing: guide/parsing.md
+    - Validation: guide/validation.md
+    - Conversion: guide/conversion.md
+    - Diffing: guide/diffing.md
+    - Writing & Editing: guide/writing.md
+    - Merging: guide/merging.md
+    - Index Utilities: guide/index_utils.md
+  - CLI Reference: cli.md
+  - API Reference: api.md
+  - CI Integration: ci.md
+  - Changelog: changelog.md
+  - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
     "ruff>=0.3",
     "mypy>=1.8",
     "typer>=0.9",
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.25",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- .readthedocs.yaml: RTD build config targeting Python 3.12
- mkdocs.yml: Material theme with tabs, search, code copy
- docs/: full site covering installation, user guide (parsing, validation, conversion, diffing, writing, merging, index utils), CLI reference, API reference, CI integration, changelog, contributing
- pyproject.toml: add mkdocs/mkdocs-material/mkdocstrings to dev deps
- .gitignore: exclude generated site/ directory