### PR TITLE
Add nf-core compatible Nextflow modules for samplesheet-parser

### DIFF
--- a/modules/nf-core/samplesheetparser/convert/environment.yml
+++ b/modules/nf-core/samplesheetparser/convert/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.1.0

--- a/modules/nf-core/samplesheetparser/convert/main.nf
+++ b/modules/nf-core/samplesheetparser/convert/main.nf
@@ -1,0 +1,50 @@
+process SAMPLESHEETPARSER_CONVERT {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.1.0--pyhdfd78af_0' :
+        'biocontainers/samplesheet-parser:1.1.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+    val target_version
+
+    output:
+    tuple val(meta), path("*.converted.csv"), emit: samplesheet
+    path "versions.yml",                      emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!['v1', 'v2'].contains(target_version.toLowerCase())) {
+        error "target_version must be 'v1' or 'v2', got: ${target_version}"
+    }
+    """
+    samplesheet convert \\
+        --to ${target_version} \\
+        --output ${prefix}.converted.csv \\
+        ${args} \\
+        ${samplesheet}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.converted.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samplesheetparser/convert/meta.yml
+++ b/modules/nf-core/samplesheetparser/convert/meta.yml
@@ -1,0 +1,62 @@
+name: samplesheetparser_convert
+description: |
+  Convert an Illumina SampleSheet.csv between IEM V1 (bcl2fastq) and
+  BCLConvert V2 formats. Format of the input is auto-detected.
+  V2 → V1 conversion is lossy: V2-only fields (OverrideCycles,
+  InstrumentPlatform, etc.) are dropped with a warning.
+keywords:
+  - illumina
+  - samplesheet
+  - conversion
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format, auto-detected)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+  - - target_version:
+        type: string
+        description: Target format — either 'v1' or 'v2'
+
+output:
+  - samplesheet:
+      - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.converted.csv":
+          type: file
+          description: Converted SampleSheet.csv in the requested format
+          pattern: "*.converted.csv"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/convert/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/convert/tests/main.nf.test
@@ -1,0 +1,79 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_CONVERT"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_CONVERT"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_convert"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 → V2 conversion") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1_to_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 → V1 conversion") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2_to_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v2.csv', checkIfExists: true)
+                ]
+                input[1] = 'v1'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 → V2 conversion - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/convert/tests/tags.yml
+++ b/modules/nf-core/samplesheetparser/convert/tests/tags.yml
@@ -1,0 +1,4 @@
+samplesheetparser:
+  - modules/nf-core/samplesheetparser/**
+samplesheetparser_convert:
+  - modules/nf-core/samplesheetparser/convert/**

--- a/modules/nf-core/samplesheetparser/info/environment.yml
+++ b/modules/nf-core/samplesheetparser/info/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.1.0

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -1,0 +1,45 @@
+process SAMPLESHEETPARSER_INFO {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.1.0--pyhdfd78af_0' :
+        'biocontainers/samplesheet-parser:1.1.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.info.json"), emit: json
+    path "versions.yml",                  emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet info \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.info.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"format": "V1", "sample_count": 0, "lanes": [], "index_type": "none"}' > ${prefix}.info.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samplesheetparser/info/meta.yml
+++ b/modules/nf-core/samplesheetparser/info/meta.yml
@@ -1,0 +1,61 @@
+name: samplesheetparser_info
+description: |
+  Display a structured JSON summary of an Illumina SampleSheet.csv (V1 or V2)
+  including format version, sample count, lanes, index type, read lengths,
+  adapter sequences, experiment name, and instrument platform.
+  Useful for logging run metadata or conditional branching in pipelines.
+keywords:
+  - illumina
+  - samplesheet
+  - metadata
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format, auto-detected)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  - json:
+      - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.info.json":
+          type: file
+          description: |
+            JSON summary with file, format, sample_count, lanes, index_type,
+            read_lengths, adapters, experiment_name, and instrument fields.
+          pattern: "*.info.json"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test
@@ -1,0 +1,76 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_INFO"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_INFO"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_info"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/info/tests/tags.yml
+++ b/modules/nf-core/samplesheetparser/info/tests/tags.yml
@@ -1,0 +1,4 @@
+samplesheetparser:
+  - modules/nf-core/samplesheetparser/**
+samplesheetparser_info:
+  - modules/nf-core/samplesheetparser/info/**

--- a/modules/nf-core/samplesheetparser/validate/environment.yml
+++ b/modules/nf-core/samplesheetparser/validate/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.1.0

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -1,0 +1,45 @@
+process SAMPLESHEETPARSER_VALIDATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.1.0--pyhdfd78af_0' :
+        'biocontainers/samplesheet-parser:1.1.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.validation.json"), emit: json
+    path "versions.yml",                        emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet validate \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.validation.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"is_valid": true, "errors": [], "warnings": []}' > ${prefix}.validation.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samplesheet-parser: \$(samplesheet --version | sed 's/samplesheet-parser //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samplesheetparser/validate/meta.yml
+++ b/modules/nf-core/samplesheetparser/validate/meta.yml
@@ -1,0 +1,62 @@
+name: samplesheetparser_validate
+description: |
+  Validate an Illumina SampleSheet.csv (V1 or V2) for index, adapter, and
+  structural issues. Format is auto-detected. Exits 0 if valid, 1 if errors
+  are found — causing the pipeline to fail early with a clear message rather
+  than discovering demultiplexing problems downstream.
+keywords:
+  - illumina
+  - samplesheet
+  - validation
+  - demultiplexing
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  - json:
+      - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.validation.json":
+          type: file
+          description: |
+            Structured JSON validation report with is_valid, errors, warnings,
+            and min_hamming_distance fields.
+          pattern: "*.validation.json"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
@@ -1,0 +1,76 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_VALIDATE"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_VALIDATE"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_validate"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 dual-index sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/samplesheets/samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/validate/tests/tags.yml
+++ b/modules/nf-core/samplesheetparser/validate/tests/tags.yml
@@ -1,0 +1,4 @@
+samplesheetparser:
+  - modules/nf-core/samplesheetparser/**
+samplesheetparser_validate:
+  - modules/nf-core/samplesheetparser/validate/**


### PR DESCRIPTION
Three modules covering the most pipeline-relevant CLI commands:

- SAMPLESHEETPARSER_VALIDATE: validates V1/V2 sheets, emits structured JSON report, exits 1 on errors so pipelines fail early before demultiplexing.
- SAMPLESHEETPARSER_CONVERT: bidirectional V1↔V2 conversion, target version passed as channel value.
- SAMPLESHEETPARSER_INFO: emits a JSON metadata summary (format, sample count, lanes, index type, read lengths, adapters) useful for run logging and conditional pipeline branching.

Each module includes main.nf, meta.yml, environment.yml, nf-test tests (two real + one stub), and tags.yml following nf-core/modules conventions.