### PR TITLE
Add split and filter commands with examples

### DIFF
--- a/examples/demo_filter.py
+++ b/examples/demo_filter.py
@@ -1,0 +1,110 @@
+"""
+demo_filter.py — SampleSheetFilter usage examples.
+
+Demonstrates four scenarios:
+
+    1. Filter by project   — keep only one project's samples.
+    2. Filter by lane      — keep only samples from a specific lane.
+    3. Filter by sample ID — exact match and glob pattern.
+    4. Combined criteria   — project + lane ANDed together.
+
+Run from the repo root::
+
+    python examples/demo_filter.py
+
+Sample sheets used are in examples/sample_sheets/.
+Output files are written to examples/sample_sheets/filtered/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from samplesheet_parser import FilterResult
+from samplesheet_parser.filter import SampleSheetFilter
+
+SHEETS = Path(__file__).parent / "sample_sheets"
+OUT = SHEETS / "filtered"
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def print_result(result: FilterResult) -> None:
+    print(f"  Summary       : {result.summary()}")
+    print(f"  Source version: {result.source_version}")
+    print(f"  Matched/Total : {result.matched_count}/{result.total_count}")
+    if result.output_path:
+        print(f"  Output        : {result.output_path.name}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Filter by project
+# Keep only ProjectAlpha samples from the combined sheet.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 1: Filter by project (keep ProjectAlpha only)")
+print("=" * 60)
+
+flt = SampleSheetFilter(SHEETS / "combined_clean.csv")
+result = flt.filter(OUT / "ProjectAlpha_only.csv", project="ProjectAlpha")
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Filter by lane
+# Keep only samples assigned to lane 1.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 2: Filter by lane (keep lane 1 only)")
+print("=" * 60)
+
+flt = SampleSheetFilter(SHEETS / "v1_multi_lane.csv")
+result = flt.filter(OUT / "lane1_only.csv", lane=1)
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 3a: Filter by sample ID — exact match
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 3a: Filter by sample ID (exact match)")
+print("=" * 60)
+
+flt = SampleSheetFilter(SHEETS / "combined_clean.csv")
+result = flt.filter(OUT / "AlphaSample1_only.csv", sample_id="AlphaSample1")
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 3b: Filter by sample ID — glob pattern
+# Keep all samples whose ID starts with "Alpha".
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 3b: Filter by sample ID glob ('Alpha*')")
+print("=" * 60)
+
+flt = SampleSheetFilter(SHEETS / "combined_clean.csv")
+result = flt.filter(OUT / "Alpha_samples.csv", sample_id="Alpha*")
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Combined criteria — project AND lane
+# Multiple criteria are ANDed: a sample must satisfy all of them.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 4: Combined criteria (project=Oncology AND lane=1)")
+print("=" * 60)
+
+flt = SampleSheetFilter(SHEETS / "v1_multi_lane.csv")
+result = flt.filter(OUT / "Oncology_lane1.csv", project="Oncology", lane=1)
+
+print_result(result)

--- a/examples/demo_splitter.py
+++ b/examples/demo_splitter.py
@@ -54,13 +54,11 @@ print_result(result)
 print()
 
 # ---------------------------------------------------------------------------
-# Scenario 2: Split by lane — same combined sheet → one file per lane
-# The combined_clean.csv has all samples on lane 1, so this produces a
-# single file. Swap in a multi-lane sheet to see multiple outputs.
+# Scenario 2: Split by lane — V1 multi-lane sheet → one file per lane
 # ---------------------------------------------------------------------------
 
 print("=" * 60)
-print("Scenario 2: Split by lane (V2 combined → per-lane files)")
+print("Scenario 2: Split by lane (V1 multi-lane → per-lane files)")
 print("=" * 60)
 
 splitter = SampleSheetSplitter(SHEETS / "v1_multi_lane.csv", by="lane")

--- a/examples/demo_splitter.py
+++ b/examples/demo_splitter.py
@@ -1,0 +1,89 @@
+"""
+demo_splitter.py — SampleSheetSplitter usage examples.
+
+Demonstrates three scenarios:
+
+    1. Split by project  — combined V2 sheet → one file per Sample_Project.
+    2. Split by lane     — same sheet → one file per lane.
+    3. Target version    — split a V2 combined sheet into V1 per-project files.
+
+Run from the repo root::
+
+    python examples/demo_splitter.py
+
+Sample sheets used are in examples/sample_sheets/.
+Output files are written to examples/sample_sheets/split/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from samplesheet_parser import SplitResult
+from samplesheet_parser.enums import SampleSheetVersion
+from samplesheet_parser.splitter import SampleSheetSplitter
+
+SHEETS = Path(__file__).parent / "sample_sheets"
+OUT = SHEETS / "split"
+
+
+def print_result(result: SplitResult) -> None:
+    print(f"  Summary       : {result.summary()}")
+    print(f"  Source version: {result.source_version}")
+    for group, path in sorted(result.output_files.items()):
+        count = result.sample_counts[group]
+        print(f"  [{group}] → {path.name}  ({count} sample(s))")
+    if result.warnings:
+        print("  Warnings:")
+        for w in result.warnings:
+            print(f"    {w}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Split by project — combined V2 → one file per Sample_Project
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 1: Split by project (V2 combined → per-project files)")
+print("=" * 60)
+
+splitter = SampleSheetSplitter(SHEETS / "combined_clean.csv", by="project")
+result = splitter.split(OUT / "by_project")
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Split by lane — same combined sheet → one file per lane
+# The combined_clean.csv has all samples on lane 1, so this produces a
+# single file. Swap in a multi-lane sheet to see multiple outputs.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 2: Split by lane (V2 combined → per-lane files)")
+print("=" * 60)
+
+splitter = SampleSheetSplitter(SHEETS / "v1_multi_lane.csv", by="lane")
+result = splitter.split(OUT / "by_lane")
+
+print_result(result)
+print()
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Target version override — split V2 input into V1 output files
+# Useful when downstream tools (bcl2fastq) require V1 format but your
+# combined sheet is V2.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 3: V2 input → V1 per-project output files")
+print("=" * 60)
+
+splitter = SampleSheetSplitter(
+    SHEETS / "combined_clean.csv",
+    by="project",
+    target_version=SampleSheetVersion.V1,
+)
+result = splitter.split(OUT / "by_project_v1", prefix="v1_")
+
+print_result(result)

--- a/samplesheet_parser/__init__.py
+++ b/samplesheet_parser/__init__.py
@@ -36,10 +36,12 @@ from samplesheet_parser.converter import SampleSheetConverter
 from samplesheet_parser.diff import DiffResult, SampleSheetDiff
 from samplesheet_parser.enums import IndexType, InstrumentPlatform, SampleSheetVersion, UMILocation
 from samplesheet_parser.factory import SampleSheetFactory
+from samplesheet_parser.filter import FilterResult, SampleSheetFilter
 from samplesheet_parser.index_utils import normalize_index_lengths
 from samplesheet_parser.merger import MergeResult, SampleSheetMerger
 from samplesheet_parser.parsers.v1 import SampleSheetV1
 from samplesheet_parser.parsers.v2 import SampleSheetV2
+from samplesheet_parser.splitter import SampleSheetSplitter, SplitResult
 from samplesheet_parser.validators import SampleSheetValidator, ValidationResult
 from samplesheet_parser.writer import SampleSheetWriter
 
@@ -59,6 +61,10 @@ __all__ = [
     "SampleSheetWriter",
     "SampleSheetMerger",
     "MergeResult",
+    "SampleSheetSplitter",
+    "SplitResult",
+    "SampleSheetFilter",
+    "FilterResult",
     "normalize_index_lengths",
     "__version__",
 ]

--- a/samplesheet_parser/cli.py
+++ b/samplesheet_parser/cli.py
@@ -10,6 +10,8 @@ validate    Validate a sheet — exit 0 if clean, exit 1 if errors.
 convert     Convert between V1 and V2 formats.
 diff        Diff two sheets — exit 1 if changes detected.
 merge       Merge multiple project sheets into one combined sheet.
+split       Split a combined sheet into per-project or per-lane files.
+filter      Extract a subset of samples by project, lane, or sample ID.
 
 Installation
 ------------
@@ -37,6 +39,13 @@ Usage
 
     samplesheet merge ProjectA.csv ProjectB.csv --output combined.csv
     samplesheet merge ProjectA.csv ProjectB.csv ProjectC.csv --output combined.csv --to v1
+
+    samplesheet split combined.csv --output-dir ./per_project/
+    samplesheet split combined.csv --by lane --output-dir ./per_lane/ --to v1
+
+    samplesheet filter SampleSheet.csv --project ProjectA --output filtered.csv
+    samplesheet filter SampleSheet.csv --lane 2 --output filtered.csv
+    samplesheet filter SampleSheet.csv --sample-id "CTRL_*" --output controls.csv
 
 Authors
 -------
@@ -551,6 +560,192 @@ if _TYPER_AVAILABLE:
 
         has_issues = result.has_conflicts or bool(result.warnings)
         raise typer.Exit(code=1 if has_issues else 0)
+
+    # ---------------------------------------------------------------------------
+    # split
+    # ---------------------------------------------------------------------------
+
+    @app.command()
+    def split(
+        path: Annotated[Path, typer.Argument(help="Input SampleSheet.csv.", metavar="FILE")],
+        by: Annotated[
+            str,
+            typer.Option(
+                "--by",
+                help="Grouping key: 'project' (default) or 'lane'.",
+                metavar="KEY",
+            ),
+        ] = "project",
+        output_dir: Annotated[
+            Path,
+            typer.Option(
+                "--output-dir",
+                "-d",
+                help="Directory in which to write the split files.",
+                metavar="DIR",
+            ),
+        ] = Path("."),
+        to: _VersionOption = "v2",
+        fmt: _FormatOption = "text",
+        prefix: Annotated[
+            str,
+            typer.Option(
+                "--prefix",
+                help="String prepended to each output filename.",
+                metavar="STR",
+            ),
+        ] = "",
+    ) -> None:
+        """Split a combined sheet into one file per project or per lane.
+
+        Header, reads, and settings are copied into every output file; only
+        the sample rows are divided.  Output filenames are
+        ``{prefix}{group}{_SampleSheet.csv}``.
+
+        Exits 0 on success.
+        Exits 1 if warnings were produced (e.g. samples with no project).
+        Exits 2 on bad arguments or unreadable files.
+        """
+        from samplesheet_parser.splitter import SampleSheetSplitter
+
+        _validate_fmt(fmt)
+        if by not in ("project", "lane"):
+            typer.echo(f"Error: --by must be 'project' or 'lane', got {by!r}.", err=True)
+            raise typer.Exit(code=2)
+        if not path.exists():
+            typer.echo(f"Error: file not found: {path}", err=True)
+            raise typer.Exit(code=2)
+
+        target = _resolve_version(to)
+
+        try:
+            splitter = SampleSheetSplitter(path, by=by, target_version=target)
+            result = splitter.split(output_dir, prefix=prefix)
+        except Exception as exc:
+            typer.echo(f"Error: split failed: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
+
+        if fmt == "json":
+            _print_json(
+                {
+                    "source_version": result.source_version,
+                    "by": by,
+                    "output_dir": str(output_dir),
+                    "summary": result.summary(),
+                    "files": {k: str(v) for k, v in result.output_files.items()},
+                    "sample_counts": result.sample_counts,
+                    "warnings": result.warnings,
+                }
+            )
+        else:
+            typer.echo(result.summary())
+            if result.output_files:
+                typer.echo(f"\nOutput files ({output_dir}):")
+                for group, out_path in sorted(result.output_files.items()):
+                    count = result.sample_counts[group]
+                    typer.echo(f"  {out_path.name}  ({count} sample(s))  [{group}]")
+            if result.warnings:
+                typer.echo("\nWarnings:")
+                for w in result.warnings:
+                    typer.echo(f"  {w}")
+
+        raise typer.Exit(code=1 if result.warnings else 0)
+
+    # ---------------------------------------------------------------------------
+    # filter
+    # ---------------------------------------------------------------------------
+
+    @app.command(name="filter")
+    def filter_cmd(
+        path: Annotated[Path, typer.Argument(help="Input SampleSheet.csv.", metavar="FILE")],
+        output: _OutputOption = Path("SampleSheet_filtered.csv"),
+        project: Annotated[
+            str,
+            typer.Option(
+                "--project",
+                "-p",
+                help="Keep only samples matching this Sample_Project (exact).",
+                metavar="NAME",
+            ),
+        ] = "",
+        lane: Annotated[
+            str,
+            typer.Option(
+                "--lane",
+                "-l",
+                help="Keep only samples from this lane.",
+                metavar="N",
+            ),
+        ] = "",
+        sample_id: Annotated[
+            str,
+            typer.Option(
+                "--sample-id",
+                "-s",
+                help="Keep only samples matching this Sample_ID or glob pattern.",
+                metavar="PATTERN",
+            ),
+        ] = "",
+        to: _VersionOption = "v2",
+        fmt: _FormatOption = "text",
+    ) -> None:
+        """Extract a subset of samples from a sheet by project, lane, or sample ID.
+
+        Multiple criteria are ANDed — a sample must match all provided
+        criteria.  ``--sample-id`` supports glob patterns (e.g. ``'CTRL_*'``).
+
+        Exits 0 if at least one sample matched.
+        Exits 1 if no samples matched the criteria.
+        Exits 2 on bad arguments or unreadable files.
+        """
+        from samplesheet_parser.filter import SampleSheetFilter
+
+        _validate_fmt(fmt)
+        if not project and not lane and not sample_id:
+            typer.echo(
+                "Error: at least one of --project, --lane, or --sample-id is required.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if not path.exists():
+            typer.echo(f"Error: file not found: {path}", err=True)
+            raise typer.Exit(code=2)
+
+        target = _resolve_version(to)
+
+        try:
+            flt = SampleSheetFilter(path, target_version=target)
+            result = flt.filter(
+                output,
+                project=project or None,
+                lane=lane or None,
+                sample_id=sample_id or None,
+            )
+        except Exception as exc:
+            typer.echo(f"Error: filter failed: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
+
+        if fmt == "json":
+            _print_json(
+                {
+                    "source_version": result.source_version,
+                    "matched_count": result.matched_count,
+                    "total_count": result.total_count,
+                    "output_path": str(result.output_path) if result.output_path else None,
+                    "summary": result.summary(),
+                    "criteria": {
+                        "project": project or None,
+                        "lane": lane or None,
+                        "sample_id": sample_id or None,
+                    },
+                }
+            )
+        else:
+            typer.echo(result.summary())
+            if result.output_path:
+                typer.echo(f"Output: {result.output_path}")
+
+        raise typer.Exit(code=0 if result.matched_count > 0 else 1)
 
 else:  # pragma: no cover
     # Fallbacks when Typer is not installed: keep simple type aliases so that

--- a/samplesheet_parser/cli.py
+++ b/samplesheet_parser/cli.py
@@ -600,7 +600,7 @@ if _TYPER_AVAILABLE:
 
         Header, reads, and settings are copied into every output file; only
         the sample rows are divided.  Output filenames are
-        ``{prefix}{group}{_SampleSheet.csv}``.
+        ``{prefix}{group}_SampleSheet.csv``.
 
         Exits 0 on success.
         Exits 1 if warnings were produced (e.g. samples with no project).

--- a/samplesheet_parser/filter.py
+++ b/samplesheet_parser/filter.py
@@ -1,0 +1,243 @@
+"""
+Filter samples from an Illumina SampleSheet.csv by project, lane, or sample ID.
+
+Examples
+--------
+>>> from samplesheet_parser.filter import SampleSheetFilter
+>>>
+>>> f = SampleSheetFilter("SampleSheet.csv")
+>>> result = f.filter("filtered.csv", project="ProjectA")
+>>> print(f"Kept {result.matched_count} of {result.total_count} samples")
+
+Combine multiple criteria (ANDed)::
+
+>>> result = f.filter("out.csv", project="ProjectA", lane="2")
+
+Use a glob pattern on Sample_ID::
+
+>>> result = f.filter("out.csv", sample_id="CTRL_*")
+
+Authors
+-------
+Chaitanya Kasaraneni
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from samplesheet_parser.enums import SampleSheetVersion
+from samplesheet_parser.factory import SampleSheetFactory
+
+# Raw record keys that are standard sample fields — not extra columns
+_STANDARD_SAMPLE_KEYS: frozenset[str] = frozenset(
+    {
+        "lane",
+        "Lane",
+        "sample_id",
+        "Sample_ID",
+        "sample_name",
+        "Sample_Name",
+        "index",
+        "Index",
+        "index2",
+        "Index2",
+        "sample_project",
+        "Sample_Project",
+        "description",
+        "Description",
+        "sample_plate",
+        "Sample_Plate",
+        "sample_well",
+        "Sample_Well",
+        "i7_index_id",
+        "I7_Index_ID",
+        "i5_index_id",
+        "I5_Index_ID",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilterResult:
+    """Structured output from :class:`SampleSheetFilter`.
+
+    Attributes
+    ----------
+    matched_count:
+        Number of samples that passed all filter criteria.
+    total_count:
+        Total number of samples in the input sheet.
+    output_path:
+        Path to the written file, or ``None`` if no samples matched and
+        no file was written.
+    source_version:
+        Format version string detected for the input sheet (e.g. ``"V2"``).
+    """
+
+    matched_count: int = 0
+    total_count: int = 0
+    output_path: Path | None = None
+    source_version: str = ""
+
+    def summary(self) -> str:
+        """Return a human-readable one-line summary."""
+        suffix = f" → {self.output_path}" if self.output_path else " (no output written)"
+        return f"Kept {self.matched_count} of {self.total_count} sample(s){suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+class SampleSheetFilter:
+    """Filter samples from a SampleSheet.csv by project, lane, or sample ID.
+
+    Header, reads, and settings from the input sheet are preserved in the
+    output; only the sample rows are filtered.
+
+    Parameters
+    ----------
+    path:
+        Path to the input SampleSheet.csv (V1 or V2).
+    target_version:
+        Output format for the filtered file.  Defaults to the same format as
+        the input sheet.
+
+    Examples
+    --------
+    >>> flt = SampleSheetFilter("combined.csv")
+    >>> result = flt.filter("projectA.csv", project="ProjectA")
+    >>> result = flt.filter("lane2.csv", lane=2)
+    >>> result = flt.filter("controls.csv", sample_id="CTRL_*")
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        target_version: SampleSheetVersion | None = None,
+    ) -> None:
+        self._path = Path(path)
+        self._target_version = target_version
+
+    def filter(
+        self,
+        output_path: str | Path,
+        *,
+        project: str | None = None,
+        lane: str | int | None = None,
+        sample_id: str | None = None,
+        validate: bool = True,
+    ) -> FilterResult:
+        """Write a filtered copy of the sheet to *output_path*.
+
+        Multiple criteria are ANDed — a sample must match **all** provided
+        criteria to be included.  ``sample_id`` supports glob patterns (e.g.
+        ``"CTRL_*"`` or ``"SAMPLE_00[1-3]"``).
+
+        Parameters
+        ----------
+        output_path:
+            Destination file path.
+        project:
+            Keep only samples whose ``Sample_Project`` matches exactly.
+        lane:
+            Keep only samples from this lane (compared as a string, so
+            ``lane=2`` and ``lane="2"`` are equivalent).
+        sample_id:
+            Keep only samples whose ``Sample_ID`` matches this value or glob
+            pattern.
+        validate:
+            Run :class:`~samplesheet_parser.validators.SampleSheetValidator`
+            on the filtered sheet before writing (default ``True``).
+
+        Returns
+        -------
+        FilterResult
+
+        Raises
+        ------
+        ValueError
+            If no filter criteria are provided.
+        FileNotFoundError
+            If the input file does not exist.
+        """
+        if project is None and lane is None and sample_id is None:
+            raise ValueError(
+                "At least one filter criterion must be provided: " "project, lane, or sample_id."
+            )
+        if not self._path.exists():
+            raise FileNotFoundError(f"SampleSheet not found: {self._path}")
+
+        factory = SampleSheetFactory()
+        sheet = factory.create_parser(str(self._path), parse=True, clean=False)
+        target_version = self._target_version or factory.version or SampleSheetVersion.V2
+
+        result = FilterResult(source_version=factory.version.value if factory.version else "")
+
+        records: list[dict[str, Any]] = getattr(sheet, "records", None) or sheet.samples()
+        result.total_count = len(records)
+        lane_str = str(lane) if lane is not None else None
+
+        from samplesheet_parser.writer import SampleSheetWriter
+
+        writer = SampleSheetWriter.from_sheet(sheet, version=target_version)
+        # from_sheet loads all samples; clear so only matched rows are added.
+        writer._samples.clear()
+
+        for record in records:
+            rec_project = record.get("sample_project") or record.get("Sample_Project") or ""
+            rec_lane = str(record.get("lane") or record.get("Lane") or "")
+            rec_sid = record.get("sample_id") or record.get("Sample_ID") or ""
+
+            if project is not None and rec_project != project:
+                continue
+            if lane_str is not None and rec_lane != lane_str:
+                continue
+            if sample_id is not None and not fnmatch.fnmatch(rec_sid, sample_id):
+                continue
+
+            idx = record.get("index") or record.get("Index") or ""
+            if not rec_sid or not idx:
+                continue
+
+            writer.add_sample(
+                rec_sid,
+                index=idx,
+                index2=record.get("index2") or record.get("Index2") or "",
+                lane=str(record.get("lane") or record.get("Lane") or "1"),
+                sample_name=record.get("sample_name") or record.get("Sample_Name") or "",
+                i7_index_id=record.get("i7_index_id") or record.get("I7_Index_ID") or "",
+                i5_index_id=record.get("i5_index_id") or record.get("I5_Index_ID") or "",
+                project=rec_project,
+                description=record.get("description") or record.get("Description") or "",
+                sample_plate=record.get("sample_plate") or record.get("Sample_Plate") or "",
+                sample_well=record.get("sample_well") or record.get("Sample_Well") or "",
+                **{
+                    k: str(v)
+                    for k, v in record.items()
+                    if k not in _STANDARD_SAMPLE_KEYS and v is not None
+                },
+            )
+            result.matched_count += 1
+
+        if result.matched_count == 0:
+            logger.warning("No samples matched the filter criteria — no output written.")
+            return result
+
+        out = writer.write(output_path, validate=validate)
+        result.output_path = out
+        logger.info(f"Filtered {result.matched_count}/{result.total_count} samples → {out}")
+        return result

--- a/samplesheet_parser/filter.py
+++ b/samplesheet_parser/filter.py
@@ -195,7 +195,7 @@ class SampleSheetFilter:
 
         writer = SampleSheetWriter.from_sheet(sheet, version=target_version)
         # from_sheet loads all samples; clear so only matched rows are added.
-        writer._samples.clear()
+        writer.clear_samples()
 
         for record in records:
             rec_project = record.get("sample_project") or record.get("Sample_Project") or ""
@@ -206,7 +206,7 @@ class SampleSheetFilter:
                 continue
             if lane_str is not None and rec_lane != lane_str:
                 continue
-            if sample_id is not None and not fnmatch.fnmatch(rec_sid, sample_id):
+            if sample_id is not None and not fnmatch.fnmatchcase(rec_sid, sample_id):
                 continue
 
             idx = record.get("index") or record.get("Index") or ""

--- a/samplesheet_parser/splitter.py
+++ b/samplesheet_parser/splitter.py
@@ -215,27 +215,33 @@ class SampleSheetSplitter:
         # ── Group records ────────────────────────────────────────────────
         groups: dict[str, list[dict[str, Any]]] = {}
         records: list[dict[str, Any]] = getattr(sheet, "records", None) or sheet.samples()
+        unassigned_count = 0
 
         for record in records:
             if self._by == "project":
-                key = (
-                    record.get("sample_project")
-                    or record.get("Sample_Project")
-                    or self._unassigned_label
-                )
+                raw = record.get("sample_project") or record.get("Sample_Project") or ""
+                if raw:
+                    key = raw
+                else:
+                    key = self._unassigned_label
+                    unassigned_count += 1
             else:  # lane
-                key = str(record.get("lane") or record.get("Lane") or self._unassigned_label)
+                raw = str(record.get("lane") or record.get("Lane") or "")
+                if raw:
+                    key = raw
+                else:
+                    key = self._unassigned_label
+                    unassigned_count += 1
             groups.setdefault(key, []).append(record)
 
         if not groups:
             result.warnings.append("No samples found in input sheet — no files written.")
             return result
 
-        if self._unassigned_label in groups:
-            count = len(groups[self._unassigned_label])
+        if unassigned_count:
             field_name = "project" if self._by == "project" else "lane"
             result.warnings.append(
-                f"{count} sample(s) have no {field_name} and will be written "
+                f"{unassigned_count} sample(s) have no {field_name} and will be written "
                 f"to '{prefix}{_safe_filename(self._unassigned_label)}{suffix}'."
             )
 
@@ -246,7 +252,7 @@ class SampleSheetSplitter:
             writer = SampleSheetWriter.from_sheet(sheet, version=target_version)
             # from_sheet loads all samples from the source; clear them so we
             # add only this group's rows.
-            writer._samples.clear()
+            writer.clear_samples()
 
             for record in group_records:
                 sid = record.get("sample_id") or record.get("Sample_ID") or ""

--- a/samplesheet_parser/splitter.py
+++ b/samplesheet_parser/splitter.py
@@ -1,0 +1,297 @@
+"""
+Split a combined Illumina SampleSheet.csv into per-project or per-lane files.
+
+This is the inverse of :class:`samplesheet_parser.merger.SampleSheetMerger`
+and the canonical workflow when distributing a run's combined sheet back to
+individual projects after demultiplexing.
+
+Examples
+--------
+>>> from samplesheet_parser.splitter import SampleSheetSplitter
+>>>
+>>> splitter = SampleSheetSplitter("SampleSheet_combined.csv")
+>>> result = splitter.split("./per_project/")
+>>> for project, path in result.output_files.items():
+...     print(f"{project}: {path} ({result.sample_counts[project]} samples)")
+
+Split by lane instead of project::
+
+>>> splitter = SampleSheetSplitter("SampleSheet.csv", by="lane")
+>>> result = splitter.split("./per_lane/")
+
+Authors
+-------
+Chaitanya Kasaraneni
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from samplesheet_parser.enums import SampleSheetVersion
+from samplesheet_parser.factory import SampleSheetFactory
+
+# Characters unsafe in filenames across Windows/macOS/Linux
+_UNSAFE_FILENAME_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f\s]+')
+
+# Raw record keys that are standard sample fields — not extra columns
+_STANDARD_SAMPLE_KEYS: frozenset[str] = frozenset(
+    {
+        "lane",
+        "Lane",
+        "sample_id",
+        "Sample_ID",
+        "sample_name",
+        "Sample_Name",
+        "index",
+        "Index",
+        "index2",
+        "Index2",
+        "sample_project",
+        "Sample_Project",
+        "description",
+        "Description",
+        "sample_plate",
+        "Sample_Plate",
+        "sample_well",
+        "Sample_Well",
+        "i7_index_id",
+        "I7_Index_ID",
+        "i5_index_id",
+        "I5_Index_ID",
+    }
+)
+
+
+def _safe_filename(name: str) -> str:
+    """Replace characters unsafe for filenames with underscores."""
+    sanitised = _UNSAFE_FILENAME_RE.sub("_", name).strip("._")
+    return sanitised or "unnamed"
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SplitResult:
+    """Structured output from :class:`SampleSheetSplitter`.
+
+    Attributes
+    ----------
+    output_files:
+        Mapping from group key (project name or lane number) to the path of
+        the file that was written for that group.
+    sample_counts:
+        Number of samples written to each output file, keyed by group key.
+    warnings:
+        Non-fatal issues encountered during the split (e.g. incomplete
+        records, groups that produced no samples).
+    source_version:
+        Format version string detected for the input sheet (e.g. ``"V1"``).
+    """
+
+    output_files: dict[str, Path] = field(default_factory=dict)
+    sample_counts: dict[str, int] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    source_version: str = ""
+
+    def summary(self) -> str:
+        """Return a human-readable one-line summary."""
+        total = sum(self.sample_counts.values())
+        return (
+            f"Split into {len(self.output_files)} file(s), "
+            f"{total} sample(s) total, "
+            f"{len(self.warnings)} warning(s)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Splitter
+# ---------------------------------------------------------------------------
+
+
+class SampleSheetSplitter:
+    """Split a combined SampleSheet.csv into per-project or per-lane files.
+
+    This is the inverse of :class:`~samplesheet_parser.merger.SampleSheetMerger`.
+    Header, reads, and settings from the input sheet are copied into every
+    output file; only the ``[Data]`` / ``[BCLConvert_Data]`` rows are divided.
+
+    Parameters
+    ----------
+    path:
+        Path to the input SampleSheet.csv (V1 or V2).
+    by:
+        Grouping strategy.  ``"project"`` (default) groups samples by
+        ``Sample_Project``; ``"lane"`` groups by lane number.
+    target_version:
+        Output format for the split files.  Defaults to the same format as
+        the input sheet.
+    unassigned_label:
+        Label used for samples that have no project (when ``by="project"``)
+        or no lane (when ``by="lane"``).  Defaults to ``"unassigned"``.
+
+    Examples
+    --------
+    >>> splitter = SampleSheetSplitter("combined.csv")
+    >>> result = splitter.split("./output/")
+    >>> print(result.summary())
+    Split into 3 file(s), 48 samples total, 0 warning(s)
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        by: str = "project",
+        target_version: SampleSheetVersion | None = None,
+        unassigned_label: str = "unassigned",
+    ) -> None:
+        if by not in ("project", "lane"):
+            raise ValueError(f"by must be 'project' or 'lane', got {by!r}")
+        self._path = Path(path)
+        self._by = by
+        self._target_version = target_version
+        self._unassigned_label = unassigned_label
+
+    def split(
+        self,
+        output_dir: str | Path,
+        *,
+        prefix: str = "",
+        suffix: str = "_SampleSheet.csv",
+        validate: bool = True,
+    ) -> SplitResult:
+        """Parse the input sheet and write one output file per group.
+
+        Output filenames are ``{prefix}{group_key}{suffix}``, where
+        ``group_key`` is the project name or lane number with filesystem-unsafe
+        characters replaced by underscores.
+
+        Parameters
+        ----------
+        output_dir:
+            Directory in which to write the split files.  Created if it does
+            not exist.
+        prefix:
+            Optional string prepended to each output filename.
+        suffix:
+            Suffix (including extension) appended to each output filename.
+            Defaults to ``"_SampleSheet.csv"``.
+        validate:
+            Run :class:`~samplesheet_parser.validators.SampleSheetValidator`
+            on each output sheet before writing (default ``True``).
+
+        Returns
+        -------
+        SplitResult
+
+        Raises
+        ------
+        FileNotFoundError
+            If the input file does not exist.
+        """
+        if not self._path.exists():
+            raise FileNotFoundError(f"SampleSheet not found: {self._path}")
+
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        result = SplitResult()
+
+        # ── Parse input ──────────────────────────────────────────────────
+        factory = SampleSheetFactory()
+        sheet = factory.create_parser(str(self._path), parse=True, clean=False)
+        result.source_version = factory.version.value if factory.version else ""
+        target_version = self._target_version or factory.version or SampleSheetVersion.V2
+
+        # ── Group records ────────────────────────────────────────────────
+        groups: dict[str, list[dict[str, Any]]] = {}
+        records: list[dict[str, Any]] = getattr(sheet, "records", None) or sheet.samples()
+
+        for record in records:
+            if self._by == "project":
+                key = (
+                    record.get("sample_project")
+                    or record.get("Sample_Project")
+                    or self._unassigned_label
+                )
+            else:  # lane
+                key = str(record.get("lane") or record.get("Lane") or self._unassigned_label)
+            groups.setdefault(key, []).append(record)
+
+        if not groups:
+            result.warnings.append("No samples found in input sheet — no files written.")
+            return result
+
+        if self._unassigned_label in groups:
+            count = len(groups[self._unassigned_label])
+            field_name = "project" if self._by == "project" else "lane"
+            result.warnings.append(
+                f"{count} sample(s) have no {field_name} and will be written "
+                f"to '{prefix}{_safe_filename(self._unassigned_label)}{suffix}'."
+            )
+
+        # ── Write one file per group ──────────────────────────────────────
+        from samplesheet_parser.writer import SampleSheetWriter
+
+        for group_key, group_records in sorted(groups.items()):
+            writer = SampleSheetWriter.from_sheet(sheet, version=target_version)
+            # from_sheet loads all samples from the source; clear them so we
+            # add only this group's rows.
+            writer._samples.clear()
+
+            for record in group_records:
+                sid = record.get("sample_id") or record.get("Sample_ID") or ""
+                idx = record.get("index") or record.get("Index") or ""
+                if not sid or not idx:
+                    missing = []
+                    if not sid:
+                        missing.append("Sample_ID")
+                    if not idx:
+                        missing.append("Index")
+                    result.warnings.append(
+                        f"Skipping incomplete record in group '{group_key}': " f"missing {missing}."
+                    )
+                    continue
+
+                writer.add_sample(
+                    sid,
+                    index=idx,
+                    index2=record.get("index2") or record.get("Index2") or "",
+                    lane=str(record.get("lane") or record.get("Lane") or "1"),
+                    sample_name=record.get("sample_name") or record.get("Sample_Name") or "",
+                    i7_index_id=record.get("i7_index_id") or record.get("I7_Index_ID") or "",
+                    i5_index_id=record.get("i5_index_id") or record.get("I5_Index_ID") or "",
+                    project=record.get("sample_project") or record.get("Sample_Project") or "",
+                    description=record.get("description") or record.get("Description") or "",
+                    sample_plate=record.get("sample_plate") or record.get("Sample_Plate") or "",
+                    sample_well=record.get("sample_well") or record.get("Sample_Well") or "",
+                    **{
+                        k: str(v)
+                        for k, v in record.items()
+                        if k not in _STANDARD_SAMPLE_KEYS and v is not None
+                    },
+                )
+
+            if writer.sample_count == 0:
+                result.warnings.append(f"Group '{group_key}' produced no valid samples — skipping.")
+                continue
+
+            filename = f"{prefix}{_safe_filename(group_key)}{suffix}"
+            out_path = out_dir / filename
+            written = writer.write(out_path, validate=validate)
+            result.output_files[group_key] = written
+            result.sample_counts[group_key] = writer.sample_count
+            logger.info(
+                f"Wrote {writer.sample_count} sample(s) → {written} " f"(group: {group_key!r})"
+            )
+
+        return result

--- a/samplesheet_parser/writer.py
+++ b/samplesheet_parser/writer.py
@@ -97,31 +97,33 @@ def _validate_field(value: str, field_name: str) -> str:
     return value
 
 
-
 # ---------------------------------------------------------------------------
 # Internal sample record
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class _SampleRecord:
     """Internal representation of a single sample row."""
-    sample_id:    str
-    index:        str
-    index2:       str        = ""
-    lane:         str        = "1"
-    sample_name:  str        = ""
-    sample_plate: str        = ""
-    sample_well:  str        = ""
-    i7_index_id:  str        = ""
-    i5_index_id:  str        = ""
-    project:      str        = ""
-    description:  str        = ""
-    extra:        dict[str, str] = field(default_factory=dict)
+
+    sample_id: str
+    index: str
+    index2: str = ""
+    lane: str = "1"
+    sample_name: str = ""
+    sample_plate: str = ""
+    sample_well: str = ""
+    i7_index_id: str = ""
+    i5_index_id: str = ""
+    project: str = ""
+    description: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
 # Writer
 # ---------------------------------------------------------------------------
+
 
 class SampleSheetWriter:
     """
@@ -151,28 +153,28 @@ class SampleSheetWriter:
         self.version = version
 
         # Header fields
-        self._run_name:    str        = ""
-        self._run_desc:    str        = ""
-        self._platform:    str        = ""
-        self._instrument:  str        = ""
-        self._date:        str        = ""
-        self._workflow:    str        = ""
-        self._chemistry:   str        = ""
-        self._iem_version: str        = "5"
+        self._run_name: str = ""
+        self._run_desc: str = ""
+        self._platform: str = ""
+        self._instrument: str = ""
+        self._date: str = ""
+        self._workflow: str = ""
+        self._chemistry: str = ""
+        self._iem_version: str = "5"
         self._extra_header: dict[str, str] = {}
 
         # Reads
-        self._read1:   int = 0
-        self._read2:   int = 0
-        self._index1:  int = 0
-        self._index2:  int = 0
+        self._read1: int = 0
+        self._read2: int = 0
+        self._index1: int = 0
+        self._index2: int = 0
 
         # Settings
-        self._adapter_read1:    str = ""
-        self._adapter_read2:    str = ""
-        self._override_cycles:  str = ""
+        self._adapter_read1: str = ""
+        self._adapter_read2: str = ""
+        self._override_cycles: str = ""
         self._software_version: str = ""
-        self._extra_settings:   dict[str, str] = {}
+        self._extra_settings: dict[str, str] = {}
 
         # Samples
         self._samples: list[_SampleRecord] = []
@@ -233,13 +235,13 @@ class SampleSheetWriter:
     def set_header(
         self,
         *,
-        run_name:   str = "",
-        run_desc:   str = "",
-        platform:   str = "",
+        run_name: str = "",
+        run_desc: str = "",
+        platform: str = "",
         instrument: str = "",
-        date_str:   str = "",
-        workflow:   str = "",
-        chemistry:  str = "",
+        date_str: str = "",
+        workflow: str = "",
+        chemistry: str = "",
         **extra: str,
     ) -> SampleSheetWriter:
         """
@@ -271,23 +273,23 @@ class SampleSheetWriter:
         SampleSheetWriter
             ``self``, for method chaining.
         """
-        _validate_field(run_name,   "run_name")
-        _validate_field(run_desc,   "run_desc")
-        _validate_field(platform,   "platform")
+        _validate_field(run_name, "run_name")
+        _validate_field(run_desc, "run_desc")
+        _validate_field(platform, "platform")
         _validate_field(instrument, "instrument")
-        _validate_field(date_str,   "date_str")
-        _validate_field(workflow,   "workflow")
-        _validate_field(chemistry,  "chemistry")
+        _validate_field(date_str, "date_str")
+        _validate_field(workflow, "workflow")
+        _validate_field(chemistry, "chemistry")
         for k, v in extra.items():
             _validate_field(k, f"extra header key '{k}'")
             _validate_field(v, k)
-        self._run_name   = run_name
-        self._run_desc   = run_desc
-        self._platform   = platform
+        self._run_name = run_name
+        self._run_desc = run_desc
+        self._platform = platform
         self._instrument = instrument
-        self._date       = date_str
-        self._workflow   = workflow
-        self._chemistry  = chemistry
+        self._date = date_str
+        self._workflow = workflow
+        self._chemistry = chemistry
         self._extra_header.update(extra)
         return self
 
@@ -298,8 +300,8 @@ class SampleSheetWriter:
     def set_reads(
         self,
         *,
-        read1:  int,
-        read2:  int = 0,
+        read1: int,
+        read2: int = 0,
         index1: int = 0,
         index2: int = 0,
     ) -> SampleSheetWriter:
@@ -322,8 +324,8 @@ class SampleSheetWriter:
         SampleSheetWriter
             ``self``, for method chaining.
         """
-        self._read1  = read1
-        self._read2  = read2
+        self._read1 = read1
+        self._read2 = read2
         self._index1 = index1
         self._index2 = index2
         return self
@@ -398,7 +400,7 @@ class SampleSheetWriter:
         SampleSheetWriter
             ``self``, for method chaining.
         """
-        _validate_field(key,   "key")
+        _validate_field(key, "key")
         _validate_field(value, key)
         self._extra_settings[key] = value
         return self
@@ -411,16 +413,16 @@ class SampleSheetWriter:
         self,
         sample_id: str,
         *,
-        index:        str,
-        index2:       str = "",
-        lane:         str = "1",
-        sample_name:  str = "",
+        index: str,
+        index2: str = "",
+        lane: str = "1",
+        sample_name: str = "",
         sample_plate: str = "",
-        sample_well:  str = "",
-        i7_index_id:  str = "",
-        i5_index_id:  str = "",
-        project:      str = "",
-        description:  str = "",
+        sample_well: str = "",
+        i7_index_id: str = "",
+        i5_index_id: str = "",
+        project: str = "",
+        description: str = "",
         **extra: str,
     ) -> SampleSheetWriter:
         """
@@ -458,17 +460,17 @@ class SampleSheetWriter:
         if not index:
             raise ValueError(f"index must not be empty for sample '{sample_id}'.")
 
-        _validate_field(sample_id,    "sample_id")
-        _validate_field(index,        "index")
-        _validate_field(index2,       "index2")
-        _validate_field(lane,         "lane")
-        _validate_field(sample_name,  "sample_name")
+        _validate_field(sample_id, "sample_id")
+        _validate_field(index, "index")
+        _validate_field(index2, "index2")
+        _validate_field(lane, "lane")
+        _validate_field(sample_name, "sample_name")
         _validate_field(sample_plate, "sample_plate")
-        _validate_field(sample_well,  "sample_well")
-        _validate_field(i7_index_id,  "i7_index_id")
-        _validate_field(i5_index_id,  "i5_index_id")
-        _validate_field(project,      "project")
-        _validate_field(description,  "description")
+        _validate_field(sample_well, "sample_well")
+        _validate_field(i7_index_id, "i7_index_id")
+        _validate_field(i5_index_id, "i5_index_id")
+        _validate_field(project, "project")
+        _validate_field(description, "description")
         for k, v in extra.items():
             _validate_field(k, f"extra key '{k}'")
             _validate_field(v, k)
@@ -522,13 +524,10 @@ class SampleSheetWriter:
         before = len(self._samples)
         if lane is not None:
             self._samples = [
-                s for s in self._samples
-                if not (s.sample_id == sample_id and s.lane == str(lane))
+                s for s in self._samples if not (s.sample_id == sample_id and s.lane == str(lane))
             ]
         else:
-            self._samples = [
-                s for s in self._samples if s.sample_id != sample_id
-            ]
+            self._samples = [s for s in self._samples if s.sample_id != sample_id]
         if len(self._samples) == before:
             raise KeyError(
                 f"Sample '{sample_id}'"
@@ -570,8 +569,15 @@ class SampleSheetWriter:
             If no matching sample is found.
         """
         _KNOWN = {
-            "index", "index2", "lane", "sample_name", "sample_plate",
-            "sample_well", "i7_index_id", "i5_index_id", "project",
+            "index",
+            "index2",
+            "lane",
+            "sample_name",
+            "sample_plate",
+            "sample_well",
+            "i7_index_id",
+            "i5_index_id",
+            "project",
             "description",
         }
         matched = False
@@ -593,6 +599,20 @@ class SampleSheetWriter:
                 + (f" in lane {lane!r}" if lane is not None else "")
                 + " not found."
             )
+        return self
+
+    def clear_samples(self) -> SampleSheetWriter:
+        """Remove all samples from the writer, preserving header/reads/settings.
+
+        Useful when you want to copy metadata from an existing sheet via
+        :meth:`from_sheet` but replace the sample rows entirely.
+
+        Returns
+        -------
+        SampleSheetWriter
+            ``self``, for method chaining.
+        """
+        self._samples.clear()
         return self
 
     @property
@@ -652,8 +672,7 @@ class SampleSheetWriter:
 
         out.write_text(content, encoding="utf-8")
         logger.info(
-            f"Wrote {self.version.value} sheet with {len(self._samples)} "
-            f"sample(s) to {out}"
+            f"Wrote {self.version.value} sheet with {len(self._samples)} " f"sample(s) to {out}"
         )
         return out.resolve()
 
@@ -722,9 +741,9 @@ class SampleSheetWriter:
 
         # [BCLConvert_Data]
         lines.append("[BCLConvert_Data]")
-        has_index2  = any(s.index2 for s in self._samples)
+        has_index2 = any(s.index2 for s in self._samples)
         has_project = any(s.project for s in self._samples)
-        extra_cols  = self._extra_columns()
+        extra_cols = self._extra_columns()
 
         cols = ["Lane", "Sample_ID", "Index"]
         if has_index2:
@@ -755,9 +774,7 @@ class SampleSheetWriter:
         lines.append(f"IEMFileVersion,{self._iem_version}")
         if self._run_name:
             lines.append(f"Experiment Name,{self._run_name}")
-        date_val = (
-            self._date or date.today().strftime("%Y-%m-%d")
-        )
+        date_val = self._date or date.today().strftime("%Y-%m-%d")
         lines.append(f"Date,{date_val}")
         if self._workflow:
             lines.append(f"Workflow,{self._workflow}")
@@ -789,14 +806,14 @@ class SampleSheetWriter:
 
         # [Data]
         lines.append("[Data]")
-        has_index2     = any(s.index2 for s in self._samples)
-        has_i7_name    = any(s.i7_index_id for s in self._samples)
-        has_i5_name    = any(s.i5_index_id for s in self._samples)
-        has_plate      = any(s.sample_plate for s in self._samples)
-        has_well       = any(s.sample_well for s in self._samples)
-        has_project    = any(s.project for s in self._samples)
-        has_desc       = any(s.description for s in self._samples)
-        extra_cols     = self._extra_columns()
+        has_index2 = any(s.index2 for s in self._samples)
+        has_i7_name = any(s.i7_index_id for s in self._samples)
+        has_i5_name = any(s.i5_index_id for s in self._samples)
+        has_plate = any(s.sample_plate for s in self._samples)
+        has_well = any(s.sample_well for s in self._samples)
+        has_project = any(s.project for s in self._samples)
+        has_desc = any(s.description for s in self._samples)
+        extra_cols = self._extra_columns()
 
         cols = ["Lane", "Sample_ID", "Sample_Name"]
         if has_plate:
@@ -860,6 +877,7 @@ class SampleSheetWriter:
         content = self.to_string()
         # Write to a temp buffer and parse back
         import tempfile
+
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".csv", delete=False, encoding="utf-8"
         ) as tmp:
@@ -867,9 +885,7 @@ class SampleSheetWriter:
             tmp_path = tmp.name
 
         try:
-            sheet = SampleSheetFactory().create_parser(
-                tmp_path, parse=True, clean=False
-            )
+            sheet = SampleSheetFactory().create_parser(tmp_path, parse=True, clean=False)
             result = SampleSheetValidator().validate(sheet)
         finally:
             Path(tmp_path).unlink(missing_ok=True)
@@ -881,15 +897,14 @@ class SampleSheetWriter:
         if not result.is_valid:
             error_lines = "\n".join(f"  {e}" for e in result.errors)
             raise ValueError(
-                f"Sheet failed validation — fix errors before writing:\n"
-                f"{error_lines}"
+                f"Sheet failed validation — fix errors before writing:\n" f"{error_lines}"
             )
 
     def _load_from_v1(self, sheet: SampleSheetV1) -> None:
         """Populate writer state from a parsed V1 sheet."""
-        self._run_name  = sheet.experiment_name or ""
-        self._date      = sheet.date or ""
-        self._workflow  = sheet.workflow or ""
+        self._run_name = sheet.experiment_name or ""
+        self._date = sheet.date or ""
+        self._workflow = sheet.workflow or ""
         self._chemistry = sheet.chemistry or ""
         self._iem_version = sheet.iem_version or "5"
 
@@ -901,75 +916,103 @@ class SampleSheetWriter:
         self._adapter_read1 = sheet.adapter_read1 or ""
         self._adapter_read2 = sheet.adapter_read2 or ""
 
-        for record in (sheet.records or []):
-            std = {k: v for k, v in record.items() if k in (
-                "Lane", "Sample_ID", "Sample_Name", "Sample_Plate",
-                "Sample_Well", "I7_Index_ID", "index", "I5_Index_ID",
-                "index2", "Sample_Project", "Description",
-            )}
-            extra = {k: v for k, v in record.items() if k not in (
-                "Lane", "Sample_ID", "Sample_Name", "Sample_Plate",
-                "Sample_Well", "I7_Index_ID", "index", "I5_Index_ID",
-                "index2", "Sample_Project", "Description",
-            )}
+        for record in sheet.records or []:
+            std = {
+                k: v
+                for k, v in record.items()
+                if k
+                in (
+                    "Lane",
+                    "Sample_ID",
+                    "Sample_Name",
+                    "Sample_Plate",
+                    "Sample_Well",
+                    "I7_Index_ID",
+                    "index",
+                    "I5_Index_ID",
+                    "index2",
+                    "Sample_Project",
+                    "Description",
+                )
+            }
+            extra = {
+                k: v
+                for k, v in record.items()
+                if k
+                not in (
+                    "Lane",
+                    "Sample_ID",
+                    "Sample_Name",
+                    "Sample_Plate",
+                    "Sample_Well",
+                    "I7_Index_ID",
+                    "index",
+                    "I5_Index_ID",
+                    "index2",
+                    "Sample_Project",
+                    "Description",
+                )
+            }
             sid = std.get("Sample_ID", "")
             idx = std.get("index", "")
             if not sid or not idx:
                 continue
-            self._samples.append(_SampleRecord(
-                sample_id=sid,
-                index=idx,
-                index2=std.get("index2", "") or "",
-                lane=std.get("Lane", "1") or "1",
-                sample_name=std.get("Sample_Name", "") or "",
-                sample_plate=std.get("Sample_Plate", "") or "",
-                sample_well=std.get("Sample_Well", "") or "",
-                i7_index_id=std.get("I7_Index_ID", "") or "",
-                i5_index_id=std.get("I5_Index_ID", "") or "",
-                project=std.get("Sample_Project", "") or "",
-                description=std.get("Description", "") or "",
-                extra=extra,
-            ))
+            self._samples.append(
+                _SampleRecord(
+                    sample_id=sid,
+                    index=idx,
+                    index2=std.get("index2", "") or "",
+                    lane=std.get("Lane", "1") or "1",
+                    sample_name=std.get("Sample_Name", "") or "",
+                    sample_plate=std.get("Sample_Plate", "") or "",
+                    sample_well=std.get("Sample_Well", "") or "",
+                    i7_index_id=std.get("I7_Index_ID", "") or "",
+                    i5_index_id=std.get("I5_Index_ID", "") or "",
+                    project=std.get("Sample_Project", "") or "",
+                    description=std.get("Description", "") or "",
+                    extra=extra,
+                )
+            )
 
     def _load_from_v2(self, sheet: SampleSheetV2) -> None:
         """Populate writer state from a parsed V2 sheet."""
         h = sheet.header or {}
-        self._run_name    = sheet.experiment_name or h.get("RunName", "")
-        self._run_desc    = h.get("RunDescription", "")
-        self._platform    = h.get("InstrumentPlatform", "")
-        self._instrument  = h.get("InstrumentType", "")
+        self._run_name = sheet.experiment_name or h.get("RunName", "")
+        self._run_desc = h.get("RunDescription", "")
+        self._platform = h.get("InstrumentPlatform", "")
+        self._instrument = h.get("InstrumentType", "")
 
         r = sheet.reads or {}
-        self._read1  = r.get("Read1Cycles", 0)
-        self._read2  = r.get("Read2Cycles", 0)
+        self._read1 = r.get("Read1Cycles", 0)
+        self._read2 = r.get("Read2Cycles", 0)
         self._index1 = r.get("Index1Cycles", 0)
         self._index2 = r.get("Index2Cycles", 0)
 
         s = sheet.settings or {}
-        self._adapter_read1    = s.get("AdapterRead1", "")
-        self._adapter_read2    = s.get("AdapterRead2", "")
-        self._override_cycles  = s.get("OverrideCycles", "")
+        self._adapter_read1 = s.get("AdapterRead1", "")
+        self._adapter_read2 = s.get("AdapterRead2", "")
+        self._override_cycles = s.get("OverrideCycles", "")
         self._software_version = s.get("SoftwareVersion", "")
         # remaining settings → extra
-        skip = {
-            "AdapterRead1", "AdapterRead2", "OverrideCycles", "SoftwareVersion"
-        }
+        skip = {"AdapterRead1", "AdapterRead2", "OverrideCycles", "SoftwareVersion"}
         for k, v in s.items():
             if k not in skip:
                 self._extra_settings[k] = v
 
         std_cols = {"Lane", "Sample_ID", "Index", "Index2", "Sample_Project"}
-        for record in (sheet.records or []):
+        for record in sheet.records or []:
             sid = record.get("Sample_ID", "")
             idx = record.get("Index", "")
             if not sid or not idx:
                 continue
             extra = {k: v for k, v in record.items() if k not in std_cols}
-            self._samples.append(_SampleRecord(
-                sample_id=sid,
-                index=idx,
-                index2=record.get("Index2", "") or "",
-                lane=record.get("Lane", "1") or "1",
-                project=record.get("Sample_Project", "") or "",
-                extra=extra,
-            ))
+            self._samples.append(
+                _SampleRecord(
+                    sample_id=sid,
+                    index=idx,
+                    index2=record.get("Index2", "") or "",
+                    lane=record.get("Lane", "1") or "1",
+                    project=record.get("Sample_Project", "") or "",
+                    extra=extra,
+                )
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1052,6 +1052,19 @@ class TestCLISplit:
         result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
         assert "Warnings" in result.output
 
+    def test_split_exception_exits_2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        from samplesheet_parser import splitter as splitter_mod
+
+        monkeypatch.setattr(
+            splitter_mod.SampleSheetSplitter,
+            "split",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert result.exit_code == 2
+
 
 # ---------------------------------------------------------------------------
 # CLI — filter
@@ -1150,19 +1163,6 @@ class TestCLIFilter:
         )
         assert "2" in result.output
         assert str(out) in result.output
-
-    def test_split_exception_exits_2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
-        out_dir = tmp_path / "split"
-        from samplesheet_parser import splitter as splitter_mod
-
-        monkeypatch.setattr(
-            splitter_mod.SampleSheetSplitter,
-            "split",
-            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
-        )
-        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
-        assert result.exit_code == 2
 
     def test_filter_exception_exits_2(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -918,3 +918,265 @@ class TestCLIUnknownFormat:
             ],
         )
         assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# split fixtures
+# ---------------------------------------------------------------------------
+
+_V2_COMBINED = """\
+[Header]
+FileFormatVersion,2
+RunName,CombinedRun
+
+[Reads]
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,10
+Index2Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Index2,Sample_Project
+1,SampleA1,ATTACTCGAT,TATAGCCTGT,ProjectA
+1,SampleA2,TCCGGAGAGA,ATAGAGGCGT,ProjectA
+1,SampleB1,GCTTGTTTCC,CGTTAGAGTT,ProjectB
+1,SampleB2,ATTCAGAAGT,CGATCTCGTT,ProjectB
+"""
+
+_V2_NO_PROJECT = """\
+[Header]
+FileFormatVersion,2
+RunName,NoProjectRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index
+1,Sample1,ATTACTCGAT
+1,Sample2,TCCGGAGAGA
+"""
+
+
+# ---------------------------------------------------------------------------
+# CLI — split
+# ---------------------------------------------------------------------------
+
+
+class TestCLISplit:
+
+    def test_split_by_project_exits_0_no_warnings(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert result.exit_code == 0
+
+    def test_split_by_project_creates_files(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert (out_dir / "ProjectA_SampleSheet.csv").exists()
+        assert (out_dir / "ProjectB_SampleSheet.csv").exists()
+
+    def test_split_by_lane(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(
+            app, ["split", str(src), "--by", "lane", "--output-dir", str(out_dir)]
+        )
+        assert result.exit_code == 0
+
+    def test_split_with_warnings_exits_1(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_NO_PROJECT)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert result.exit_code == 1
+
+    def test_split_json_output(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(
+            app, ["split", str(src), "--output-dir", str(out_dir), "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "files" in data
+        assert "sample_counts" in data
+        assert data["by"] == "project"
+
+    def test_split_missing_file_exits_2(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["split", str(tmp_path / "missing.csv"), "--output-dir", str(tmp_path)]
+        )
+        assert result.exit_code == 2
+
+    def test_split_invalid_by_exits_2(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        result = runner.invoke(
+            app,
+            ["split", str(src), "--by", "sample", "--output-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 2
+
+    def test_split_unknown_format_exits_2(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        result = runner.invoke(
+            app,
+            ["split", str(src), "--output-dir", str(tmp_path), "--format", "xml"],
+        )
+        assert result.exit_code == 2
+
+    def test_split_with_prefix(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir), "--prefix", "Run_"])
+        assert (out_dir / "Run_ProjectA_SampleSheet.csv").exists()
+
+    def test_split_text_output_lists_files(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert "ProjectA" in result.output
+        assert "ProjectB" in result.output
+
+    def test_split_text_output_shows_warnings(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_NO_PROJECT)
+        out_dir = tmp_path / "split"
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert "Warnings" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI — filter
+# ---------------------------------------------------------------------------
+
+
+class TestCLIFilter:
+
+    def test_filter_by_project_exits_0(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app, ["filter", str(src), "--project", "ProjectA", "--output", str(out)]
+        )
+        assert result.exit_code == 0
+
+    def test_filter_by_project_writes_file(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        runner.invoke(app, ["filter", str(src), "--project", "ProjectA", "--output", str(out)])
+        assert out.exists()
+        content = out.read_text()
+        assert "SampleA1" in content
+        assert "SampleB1" not in content
+
+    def test_filter_by_lane(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(app, ["filter", str(src), "--lane", "1", "--output", str(out)])
+        assert result.exit_code == 0
+
+    def test_filter_by_sample_id_glob(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app, ["filter", str(src), "--sample-id", "SampleA*", "--output", str(out)]
+        )
+        assert result.exit_code == 0
+
+    def test_filter_no_match_exits_1(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app,
+            ["filter", str(src), "--project", "NonExistent", "--output", str(out)],
+        )
+        assert result.exit_code == 1
+
+    def test_filter_no_criteria_exits_2(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(app, ["filter", str(src), "--output", str(out)])
+        assert result.exit_code == 2
+
+    def test_filter_missing_file_exits_2(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "filter",
+                str(tmp_path / "missing.csv"),
+                "--project",
+                "X",
+                "--output",
+                str(tmp_path / "out.csv"),
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_filter_unknown_format_exits_2(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app,
+            ["filter", str(src), "--project", "ProjectA", "--output", str(out), "--format", "xml"],
+        )
+        assert result.exit_code == 2
+
+    def test_filter_json_output(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app,
+            ["filter", str(src), "--project", "ProjectA", "--output", str(out), "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["matched_count"] == 2
+        assert data["total_count"] == 4
+        assert data["criteria"]["project"] == "ProjectA"
+
+    def test_filter_text_output_shows_summary(self, tmp_path: Path) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        result = runner.invoke(
+            app, ["filter", str(src), "--project", "ProjectA", "--output", str(out)]
+        )
+        assert "2" in result.output
+        assert str(out) in result.output
+
+    def test_split_exception_exits_2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out_dir = tmp_path / "split"
+        from samplesheet_parser import splitter as splitter_mod
+
+        monkeypatch.setattr(
+            splitter_mod.SampleSheetSplitter,
+            "split",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = runner.invoke(app, ["split", str(src), "--output-dir", str(out_dir)])
+        assert result.exit_code == 2
+
+    def test_filter_exception_exits_2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        src = _write(tmp_path, "combined.csv", _V2_COMBINED)
+        out = tmp_path / "filtered.csv"
+        from samplesheet_parser import filter as filter_mod
+
+        monkeypatch.setattr(
+            filter_mod.SampleSheetFilter,
+            "filter",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = runner.invoke(
+            app, ["filter", str(src), "--project", "ProjectA", "--output", str(out)]
+        )
+        assert result.exit_code == 2

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,380 @@
+"""
+Tests for samplesheet_parser.filter.SampleSheetFilter.
+
+Covers:
+- Filter by project (exact match)
+- Filter by lane (string and int)
+- Filter by sample_id (exact and glob pattern)
+- Multiple criteria ANDed together
+- No matches → no file written, matched_count=0, exit via FilterResult
+- Header/reads/settings preserved in filtered output
+- V1 and V2 input sheets
+- Target version override (V2 input → V1 output)
+- FilterResult.summary() reflects outcome
+- ValueError when no criteria provided
+- FileNotFoundError on missing input
+- Public import from samplesheet_parser
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from samplesheet_parser.filter import SampleSheetFilter
+
+# ---------------------------------------------------------------------------
+# Sheet content
+# ---------------------------------------------------------------------------
+
+_V2_MULTI = """\
+[Header]
+FileFormatVersion,2
+RunName,CombinedRun
+
+[Reads]
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,10
+Index2Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Index2,Sample_Project
+1,SampleA1,ATTACTCGAT,TATAGCCTGT,ProjectA
+1,SampleA2,TCCGGAGAGA,ATAGAGGCGT,ProjectA
+2,SampleB1,GCTTGTTTCC,CGTTAGAGTT,ProjectB
+2,SampleB2,ATTCAGAAGT,CGATCTCGTT,ProjectB
+1,CTRL_A,GAATAATCCT,ACGGAGCGTT,Controls
+2,CTRL_B,TAAGGCGAAT,GCGTAAGATT,Controls
+"""
+
+_V1_MULTI = """\
+[Header]
+IEMFileVersion,5
+Experiment Name,CombinedRun
+Date,2024-01-15
+Workflow,GenerateFASTQ
+Chemistry,Amplicon
+
+[Reads]
+151
+151
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+
+[Data]
+Lane,Sample_ID,Sample_Name,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project
+1,SampleA1,SampleA1,D701,ATTACTCG,D501,TATAGCCT,ProjectA
+1,SampleA2,SampleA2,D702,TCCGGAGA,D502,ATAGAGGC,ProjectA
+2,SampleB1,SampleB1,D703,GCTTGTTT,D503,CGTTAGAG,ProjectB
+2,SampleB2,SampleB2,D704,ATTCAGAA,D504,CGATCTCG,ProjectB
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests — filter by project
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_project_keeps_matching_samples(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    assert result.matched_count == 2
+    assert result.total_count == 6
+    assert out.exists()
+
+
+def test_filter_by_project_excludes_other_projects(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    content = out.read_text(encoding="utf-8")
+    assert "SampleA1" in content
+    assert "SampleA2" in content
+    assert "SampleB1" not in content
+    assert "CTRL_A" not in content
+
+
+def test_filter_by_project_v1_input(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V1_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectB")
+
+    assert result.matched_count == 2
+    content = out.read_text(encoding="utf-8")
+    assert "SampleB1" in content
+    assert "SampleA1" not in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — filter by lane
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_lane_string(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, lane="1")
+
+    assert result.matched_count == 3  # SampleA1, SampleA2, CTRL_A
+
+
+def test_filter_by_lane_int(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, lane=2)
+
+    assert result.matched_count == 3  # SampleB1, SampleB2, CTRL_B
+
+
+def test_filter_by_lane_excludes_other_lanes(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    SampleSheetFilter(src).filter(out, lane="1")
+
+    content = out.read_text(encoding="utf-8")
+    assert "SampleA1" in content
+    assert "SampleB1" not in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — filter by sample_id
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_sample_id_exact(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, sample_id="SampleA1")
+
+    assert result.matched_count == 1
+    content = out.read_text(encoding="utf-8")
+    assert "SampleA1" in content
+    assert "SampleA2" not in content
+
+
+def test_filter_by_sample_id_glob_prefix(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, sample_id="CTRL_*")
+
+    assert result.matched_count == 2
+    content = out.read_text(encoding="utf-8")
+    assert "CTRL_A" in content
+    assert "CTRL_B" in content
+    assert "SampleA1" not in content
+
+
+def test_filter_by_sample_id_glob_wildcard(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, sample_id="Sample*")
+
+    assert result.matched_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Tests — multiple criteria (ANDed)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_project_and_lane(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA", lane="1")
+
+    assert result.matched_count == 2
+    content = out.read_text(encoding="utf-8")
+    assert "SampleA1" in content
+    assert "SampleB1" not in content
+
+
+def test_filter_project_and_sample_id_glob(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA", sample_id="SampleA1")
+
+    assert result.matched_count == 1
+
+
+def test_filter_lane_and_sample_id(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, lane="1", sample_id="CTRL_*")
+
+    assert result.matched_count == 1  # only CTRL_A is in lane 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — no matches
+# ---------------------------------------------------------------------------
+
+
+def test_filter_no_match_returns_zero_count(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="NonExistentProject")
+
+    assert result.matched_count == 0
+    assert result.output_path is None
+    assert not out.exists()
+
+
+def test_filter_no_match_summary_has_no_output(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="Ghost")
+
+    assert "no output" in result.summary().lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — header/settings preservation
+# ---------------------------------------------------------------------------
+
+
+def test_filter_preserves_header_and_settings(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    content = out.read_text(encoding="utf-8")
+    assert "[Header]" in content
+    assert "FileFormatVersion,2" in content
+    assert "[Reads]" in content
+    assert "Read1Cycles,151" in content
+    assert "AdapterRead1" in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — target version override
+# ---------------------------------------------------------------------------
+
+
+def test_filter_target_version_v1_from_v2_input(tmp_path: Path) -> None:
+    from samplesheet_parser.enums import SampleSheetVersion
+
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    SampleSheetFilter(src, target_version=SampleSheetVersion.V1).filter(out, project="ProjectA")
+
+    content = out.read_text(encoding="utf-8")
+    assert "IEMFileVersion" in content
+    assert "[Data]" in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — FilterResult
+# ---------------------------------------------------------------------------
+
+
+def test_filter_result_total_count(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    assert result.total_count == 6
+
+
+def test_filter_result_output_path_set_on_match(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    assert result.output_path is not None
+    assert result.output_path.exists()
+
+
+def test_filter_result_summary_contains_counts(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    summary = result.summary()
+    assert "2" in summary
+    assert "6" in summary
+
+
+def test_filter_result_source_version(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    assert result.source_version == "V2"
+
+
+# ---------------------------------------------------------------------------
+# Tests — incomplete records that pass filter criteria
+# ---------------------------------------------------------------------------
+
+_V2_INCOMPLETE_MATCH = """\
+[Header]
+FileFormatVersion,2
+RunName,IncompleteRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Sample_Project
+1,SampleA1,ATTACTCGAT,ProjectA
+1,,TCCGGAGAGA,ProjectA
+"""
+
+
+def test_filter_incomplete_record_matching_project_skipped(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_INCOMPLETE_MATCH)
+    out = tmp_path / "filtered.csv"
+    result = SampleSheetFilter(src).filter(out, project="ProjectA")
+
+    assert result.matched_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — error conditions
+# ---------------------------------------------------------------------------
+
+
+def test_filter_no_criteria_raises_value_error(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI)
+    with pytest.raises(ValueError, match="At least one filter criterion"):
+        SampleSheetFilter(src).filter(tmp_path / "out.csv")
+
+
+def test_filter_missing_input_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        SampleSheetFilter(tmp_path / "nonexistent.csv").filter(
+            tmp_path / "out.csv", project="ProjectA"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests — public import
+# ---------------------------------------------------------------------------
+
+
+def test_filter_importable_from_package() -> None:
+    from samplesheet_parser import FilterResult, SampleSheetFilter  # noqa: F401

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,466 @@
+"""
+Tests for samplesheet_parser.splitter.SampleSheetSplitter.
+
+Covers:
+- Split by project: one file per Sample_Project
+- Split by lane: one file per lane
+- Header/reads/settings are preserved in each output file
+- Samples with no project grouped under 'unassigned' with a warning
+- Incomplete records (missing Sample_ID or Index) produce warnings and are skipped
+- Empty input (no samples) returns a warning and no files
+- Target version override (V2 input → V1 output)
+- Custom prefix and suffix in output filenames
+- SplitResult.summary() reflects outcome
+- FileNotFoundError on missing input
+- ValueError on invalid --by value
+- Output directory is created if it does not exist
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from samplesheet_parser.splitter import SampleSheetSplitter
+
+# ---------------------------------------------------------------------------
+# Sheet content fixtures
+# ---------------------------------------------------------------------------
+
+_V2_MULTI_PROJECT = """\
+[Header]
+FileFormatVersion,2
+RunName,CombinedRun
+
+[Reads]
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,10
+Index2Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Index2,Sample_Project
+1,SampleA1,ATTACTCGAT,TATAGCCTGT,ProjectA
+1,SampleA2,TCCGGAGAGA,ATAGAGGCGT,ProjectA
+1,SampleB1,GCTTGTTTCC,CGTTAGAGTT,ProjectB
+1,SampleB2,ATTCAGAAGT,CGATCTCGTT,ProjectB
+1,SampleC1,GAATAATCCT,ACGGAGCGTT,ProjectC
+"""
+
+_V2_MULTI_LANE = """\
+[Header]
+FileFormatVersion,2
+RunName,MultiLaneRun
+
+[Reads]
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,10
+Index2Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Index2,Sample_Project
+1,Sample1,ATTACTCGAT,TATAGCCTGT,ProjectA
+1,Sample2,TCCGGAGAGA,ATAGAGGCGT,ProjectA
+2,Sample3,GCTTGTTTCC,CGTTAGAGTT,ProjectB
+2,Sample4,ATTCAGAAGT,CGATCTCGTT,ProjectB
+"""
+
+_V2_NO_PROJECT = """\
+[Header]
+FileFormatVersion,2
+RunName,NoProjectRun
+
+[Reads]
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,10
+Index2Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Index2
+1,Sample1,ATTACTCGAT,TATAGCCTGT
+1,Sample2,TCCGGAGAGA,ATAGAGGCGT
+"""
+
+_V1_MULTI_PROJECT = """\
+[Header]
+IEMFileVersion,5
+Experiment Name,CombinedRun
+Date,2024-01-15
+Workflow,GenerateFASTQ
+Chemistry,Amplicon
+
+[Reads]
+151
+151
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+
+[Data]
+Lane,Sample_ID,Sample_Name,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project
+1,SampleA1,SampleA1,D701,ATTACTCG,D501,TATAGCCT,ProjectA
+1,SampleA2,SampleA2,D702,TCCGGAGA,D502,ATAGAGGC,ProjectA
+1,SampleB1,SampleB1,D703,GCTTGTTT,D503,CGTTAGAG,ProjectB
+1,SampleB2,SampleB2,D704,ATTCAGAA,D504,CGATCTCG,ProjectB
+"""
+
+_V2_INCOMPLETE = """\
+[Header]
+FileFormatVersion,2
+RunName,IncompleteRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Sample_Project
+1,SampleA1,ATTACTCGAT,ProjectA
+1,,TCCGGAGAGA,ProjectA
+1,SampleB1,GCTTGTTTCC,ProjectB
+"""
+
+_V2_EMPTY = """\
+[Header]
+FileFormatVersion,2
+RunName,EmptyRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Sample_Project
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests — split by project
+# ---------------------------------------------------------------------------
+
+
+def test_split_by_project_creates_one_file_per_project(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert set(result.output_files.keys()) == {"ProjectA", "ProjectB", "ProjectC"}
+    assert result.sample_counts["ProjectA"] == 2
+    assert result.sample_counts["ProjectB"] == 2
+    assert result.sample_counts["ProjectC"] == 1
+    assert not result.warnings
+
+
+def test_split_by_project_output_files_exist(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    for path in result.output_files.values():
+        assert path.exists()
+
+
+def test_split_by_project_each_file_contains_correct_samples(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    project_a_content = result.output_files["ProjectA"].read_text(encoding="utf-8")
+    assert "SampleA1" in project_a_content
+    assert "SampleA2" in project_a_content
+    assert "SampleB1" not in project_a_content
+
+    project_b_content = result.output_files["ProjectB"].read_text(encoding="utf-8")
+    assert "SampleB1" in project_b_content
+    assert "SampleB2" in project_b_content
+    assert "SampleA1" not in project_b_content
+
+
+def test_split_by_project_header_preserved_in_each_file(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    for path in result.output_files.values():
+        content = path.read_text(encoding="utf-8")
+        assert "[Header]" in content
+        assert "FileFormatVersion,2" in content
+        assert "[Reads]" in content
+        assert "Read1Cycles,151" in content
+        assert "AdapterRead1" in content
+
+
+def test_split_by_project_v1_input(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V1_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert set(result.output_files.keys()) == {"ProjectA", "ProjectB"}
+    assert result.sample_counts["ProjectA"] == 2
+    assert result.sample_counts["ProjectB"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests — split by lane
+# ---------------------------------------------------------------------------
+
+
+def test_split_by_lane_creates_one_file_per_lane(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_LANE)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src, by="lane").split(out_dir)
+
+    assert set(result.output_files.keys()) == {"1", "2"}
+    assert result.sample_counts["1"] == 2
+    assert result.sample_counts["2"] == 2
+
+
+def test_split_by_lane_each_file_contains_correct_samples(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_LANE)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src, by="lane").split(out_dir)
+
+    lane1_content = result.output_files["1"].read_text(encoding="utf-8")
+    assert "Sample1" in lane1_content
+    assert "Sample3" not in lane1_content
+
+    lane2_content = result.output_files["2"].read_text(encoding="utf-8")
+    assert "Sample3" in lane2_content
+    assert "Sample1" not in lane2_content
+
+
+# ---------------------------------------------------------------------------
+# Tests — unassigned samples
+# ---------------------------------------------------------------------------
+
+
+def test_split_no_project_grouped_under_unassigned(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_NO_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert "unassigned" in result.output_files
+    assert result.sample_counts["unassigned"] == 2
+    assert len(result.warnings) == 1
+    assert "unassigned" in result.warnings[0]
+
+
+def test_split_custom_unassigned_label(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_NO_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src, unassigned_label="misc").split(out_dir)
+
+    assert "misc" in result.output_files
+
+
+# ---------------------------------------------------------------------------
+# Tests — incomplete records
+# ---------------------------------------------------------------------------
+
+_V2_MISSING_INDEX = """\
+[Header]
+FileFormatVersion,2
+RunName,MissingIndexRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Sample_Project
+1,SampleA1,ATTACTCGAT,ProjectA
+1,SampleA2,,ProjectA
+"""
+
+_V2_ALL_INCOMPLETE = """\
+[Header]
+FileFormatVersion,2
+RunName,AllIncompleteRun
+
+[Reads]
+Read1Cycles,151
+Index1Cycles,10
+
+[BCLConvert_Settings]
+AdapterRead1,CTGTCTCTTATACACATCT
+
+[BCLConvert_Data]
+Lane,Sample_ID,Index,Sample_Project
+1,,ATTACTCGAT,ProjectA
+1,,TCCGGAGAGA,ProjectA
+"""
+
+
+def test_split_incomplete_records_skipped_with_warning(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_INCOMPLETE)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert result.sample_counts["ProjectA"] == 1
+    assert result.sample_counts["ProjectB"] == 1
+    assert any("incomplete" in w.lower() or "missing" in w.lower() for w in result.warnings)
+
+
+def test_split_record_missing_index_warns(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MISSING_INDEX)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert result.sample_counts["ProjectA"] == 1
+    assert any("Index" in w for w in result.warnings)
+
+
+def test_split_group_all_incomplete_skipped(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_ALL_INCOMPLETE)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert "ProjectA" not in result.output_files
+    assert any("no valid samples" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Tests — empty input
+# ---------------------------------------------------------------------------
+
+
+def test_split_empty_sheet_returns_warning_no_files(tmp_path: Path) -> None:
+    src = _write(tmp_path, "empty.csv", _V2_EMPTY)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert not result.output_files
+    assert result.warnings
+
+
+# ---------------------------------------------------------------------------
+# Tests — target version override
+# ---------------------------------------------------------------------------
+
+
+def test_split_target_version_v1_from_v2_input(tmp_path: Path) -> None:
+    from samplesheet_parser.enums import SampleSheetVersion
+
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src, target_version=SampleSheetVersion.V1).split(out_dir)
+
+    for path in result.output_files.values():
+        content = path.read_text(encoding="utf-8")
+        assert "IEMFileVersion" in content
+        assert "[Data]" in content
+
+
+# ---------------------------------------------------------------------------
+# Tests — filename customisation
+# ---------------------------------------------------------------------------
+
+
+def test_split_custom_prefix(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir, prefix="Run001_")
+
+    for fname in [p.name for p in result.output_files.values()]:
+        assert fname.startswith("Run001_")
+
+
+def test_split_custom_suffix(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir, suffix=".csv")
+
+    for fname in [p.name for p in result.output_files.values()]:
+        assert fname.endswith(".csv")
+        assert "_SampleSheet" not in fname
+
+
+# ---------------------------------------------------------------------------
+# Tests — output directory creation
+# ---------------------------------------------------------------------------
+
+
+def test_split_creates_output_directory(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "nested" / "output"
+    assert not out_dir.exists()
+    SampleSheetSplitter(src).split(out_dir)
+    assert out_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests — SplitResult
+# ---------------------------------------------------------------------------
+
+
+def test_split_result_summary_reflects_outcome(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    summary = result.summary()
+    assert "3" in summary  # 3 files
+    assert "5" in summary  # 5 samples total
+
+
+def test_split_result_source_version(tmp_path: Path) -> None:
+    src = _write(tmp_path, "combined.csv", _V2_MULTI_PROJECT)
+    out_dir = tmp_path / "split"
+    result = SampleSheetSplitter(src).split(out_dir)
+
+    assert result.source_version == "V2"
+
+
+# ---------------------------------------------------------------------------
+# Tests — error conditions
+# ---------------------------------------------------------------------------
+
+
+def test_split_missing_input_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        SampleSheetSplitter(tmp_path / "nonexistent.csv").split(tmp_path)
+
+
+def test_split_invalid_by_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="by must be"):
+        SampleSheetSplitter("any.csv", by="sample")
+
+
+# ---------------------------------------------------------------------------
+# Tests — public import
+# ---------------------------------------------------------------------------
+
+
+def test_splitter_importable_from_package() -> None:
+    from samplesheet_parser import SampleSheetSplitter, SplitResult  # noqa: F401


### PR DESCRIPTION
Adds SampleSheetSplitter and SampleSheetFilter — the inverse of merge — allowing a combined sheet to be split into per-project or per-lane files, and arbitrary subsets to be extracted by project, lane, or sample ID (with glob support). Both are exposed as CLI commands (split, filter) and as public API classes. Includes 46 new tests each for splitter and filter, CLI tests for both commands, and example scripts in examples/.